### PR TITLE
Increase header contrast.

### DIFF
--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -1,25 +1,25 @@
 <header class="w-100 pa3 ph5-ns bg-near-white">
   <div class="dt w-100">
     <div class="dtc v-mid tl w-50">
-      <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-50 dim" title="Home">
+      <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-60 dim" title="Home">
         Tachyons
         <div class="dib">
-          <small class="nowrap f6 mt2 mt3-ns pr2 black-50 fw2">v4.0.0-beta-5</small>
+          <small class="nowrap f6 mt2 mt3-ns pr2 black-60 fw2">v4.0.0-beta-5</small>
         </div>
       </a>
     </div>
     <div class="db dtc v-mid w-100 tr">
 
       <a title="Documentation" href="/docs/"
-         class="f6 b dim link black-50 mr1 mr3-m mr4-l dib">
+         class="f6 b dim link black-60 mr1 mr3-m mr4-l dib">
         Docs
       </a>
       <a title="Tachyons on GitHub" href="http://github.com/mrmrs/tachyons/"
-         class="f6 b dim link black-50 mr1 mr3-m mr4-l dib">
+         class="f6 b dim link black-60 mr1 mr3-m mr4-l dib">
         GitHub
       </a>
       <a title="Tachyons Npm Modules" href="/#npm"
-         class="f6 b link black-50 dim dib">
+         class="f6 b link black-60 dim dib">
         Npm
       </a>
     </div>


### PR DESCRIPTION
Hi, I have checked the website with tota11y http://khan.github.io/tota11y/ and it complains that header contrast is insufficient. Bumping it to black-60 seems to fix the issue. The home page does claim ‘No matter the lighting, or the device, font-sizes should be large enough and contrast should be high enough.’ so you might want to fix this.