### PR TITLE
Remove justified text-align example

### DIFF
--- a/docs/typography/text-align/index.html
+++ b/docs/typography/text-align/index.html
@@ -91,13 +91,6 @@
         <p class="tc measure bg-black-10">
           Aligned to the center
         </p>
-        <h3 class="f5 fw4 pt4 caps">Justified Text</h3>
-        <p class="tj measure bg-black-10">
-          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
-          tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
-          vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
-          no sea takimata sanctus est Lorem ipsum dolor sit amet.
-        </p>
         <div class="mt5 cf">
           <div class="dib mr4">
             <h1 class="f4 ttu tracked fw6">Previous</h1>

--- a/src/templates/docs/text-align/index.html
+++ b/src/templates/docs/text-align/index.html
@@ -55,13 +55,6 @@
         <p class="tc measure bg-black-10">
           Aligned to the center
         </p>
-        <h3 class="f5 fw4 pt4 caps">Justified Text</h3>
-        <p class="tj measure bg-black-10">
-          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
-          tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
-          vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
-          no sea takimata sanctus est Lorem ipsum dolor sit amet.
-        </p>
         <div class="mt5 cf">
           <div class="dib mr4">
             <h1 class="f4 ttu tracked fw6">Previous</h1>


### PR DESCRIPTION
Since there's no longer a text-justified `.tj` class in `text-align`, it doesn't make sense to have an example for it.