### PR TITLE
Show .ttu and .tracked are separate classes

### DIFF
--- a/docs/typography/text-transform/index.html
+++ b/docs/typography/text-transform/index.html
@@ -77,7 +77,7 @@
       </article>
       <div class="ph3 ph5-ns pt4 pb5">
         <h2 class="f3 b">Examples</h2>
-        <h3 class="fw4 ttu mbn">uppercase</h3>
+        <h3 class="fw4 ttu mbn">Uppercase</h3>
         <code class="code">.ttu </code>
         <h3 class="fw4 ttl mbn">LOWERCASE</h3>
         <code class="code">.ttl </code>
@@ -86,7 +86,7 @@
         <h3 class="fw4 ttn mbn">TEXT Transform none</h3>
         <code class="code">.ttn</code>
         <h3 class="fw4 ttu tracked mbn">Uppercase with tracking</h3>
-        <code class="code">.ttu tracked</code>
+        <code class="code">.ttu.tracked</code>
 
         <div class="mt5 cf">
           <div class="dib mr4">

--- a/src/templates/docs/text-transform/index.html
+++ b/src/templates/docs/text-transform/index.html
@@ -41,7 +41,7 @@
       </article>
       <div class="ph3 ph5-ns pt4 pb5">
         <h2 class="f3 b">Examples</h2>
-        <h3 class="fw4 ttu mbn">uppercase</h3>
+        <h3 class="fw4 ttu mbn">Uppercase</h3>
         <code class="code">.ttu </code>
         <h3 class="fw4 ttl mbn">LOWERCASE</h3>
         <code class="code">.ttl </code>
@@ -50,7 +50,7 @@
         <h3 class="fw4 ttn mbn">TEXT Transform none</h3>
         <code class="code">.ttn</code>
         <h3 class="fw4 ttu tracked mbn">Uppercase with tracking</h3>
-        <code class="code">.ttu tracked</code>
+        <code class="code">.ttu.tracked</code>
 
         <div class="mt5 cf">
           <div class="dib mr4">


### PR DESCRIPTION
In the `text-transform` docs, there was a typo: `.ttu tracked`. I've fixed it to `.ttu.tracked`, demonstrating the two are separate classes.