### PR TITLE
Add strikethrough text-decoration example

### DIFF
--- a/docs/typography/text-decoration/index.html
+++ b/docs/typography/text-decoration/index.html
@@ -85,6 +85,8 @@
       vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
       no sea takimata sanctus est Lorem ipsum dolor sit amet.
       </p>
+        <h3 class="f5 fw4 pt4 ttu tracked">Text Decoration Strikethrough</h3>
+        <p class="strike">Lorem ipsum dolor sit amet</p>
         <div class="mt5 cf">
           <div class="dib mr4">
             <h1 class="f4 ttu tracked fw6">Previous</h1>

--- a/src/templates/docs/text-decoration/index.html
+++ b/src/templates/docs/text-decoration/index.html
@@ -49,6 +49,8 @@
       vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
       no sea takimata sanctus est Lorem ipsum dolor sit amet.
       </p>
+        <h3 class="f5 fw4 pt4 ttu tracked">Text Decoration Strikethrough</h3>
+        <p class="strike">Lorem ipsum dolor sit amet</p>
         <div class="mt5 cf">
           <div class="dib mr4">
             <h1 class="f4 ttu tracked fw6">Previous</h1>


### PR DESCRIPTION
The `text-decoration` module has a `.strike` utility class, so I've added an example demonstrating it.

<img width="515" alt="screenshot 2016-03-24 14 53 55" src="https://cloud.githubusercontent.com/assets/5074763/14027889/412d5466-f1d0-11e5-9e34-48940d111dd2.png">
