### PR TITLE
Update floats source css

### DIFF
--- a/docs/layout/floats/index.html
+++ b/docs/layout/floats/index.html
@@ -168,7 +168,7 @@
 @media (--breakpoint-not-small) {
   .fl-ns { float: left; display: inline; }
   .fr-ns { float: right;display: inline; }
-  .fn-ns { float: none!important; }
+  .fn-ns { float: none; }
 }
 
 @media (--breakpoint-medium) {

--- a/src/css/_floats.css
+++ b/src/css/_floats.css
@@ -39,7 +39,7 @@
 @media (--breakpoint-not-small) {
   .fl-ns { float: left; display: inline; }
   .fr-ns { float: right;display: inline; }
-  .fn-ns { float: none!important; }
+  .fn-ns { float: none; }
 }
 
 @media (--breakpoint-medium) {


### PR DESCRIPTION
There seems to have been a discrepancy between the real css from `floats` and the source css in the docs. Fixed it here. Btw, is there a script to update all these automatically?