### PR TITLE
Improve max widths docs

### DIFF
--- a/docs/layout/max-widths/index.html
+++ b/docs/layout/max-widths/index.html
@@ -108,50 +108,62 @@ Media Query Extensions:
         <table border="0" cellspacing="5" cellpadding="5">
           <tr>
             <td>
-              <code class="code">.mw1</code>
+              <code class="code mr2">.mw1</code>
             </td>
             <td>
-              <div class="mw1 bg-black-10 pv2 oh">
+              <div class="mw1 bg-black-10 pa2 mv1">
                 Lorem
               </div>
             </td>
           </tr>
           <tr>
             <td>
-              <code class="code">.mw2</code>
+              <code class="code mr2">.mw2</code>
             </td>
             <td>
-              <div class="mw2 bg-black-10 pv2 oh">
+              <div class="mw2 bg-black-10 pa2 mv1">
                 Lorem
               </div>
             </td>
           </tr>
           <tr>
             <td>
-              <code class="code">.mw3</code>
+              <code class="code mr2">.mw3</code>
             </td>
             <td>
-              <div class="mw3 bg-black-10 pv2 oh">
+              <div class="mw3 bg-black-10 pa2 mv1">
                 Lorem ipsum dolor sit amet, consetetur sadipscing
               </div>
             </td>
           </tr>
           <tr>
             <td>
-              <code class="code">.mw4</code>
+              <code class="code mr2">.mw4</code>
             </td>
             <td>
-              <div class="mw4 bg-black-10 pv2 oh">
+              <div class="mw4 bg-black-10 pa2 mv1">
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod.
               </div>
             </td>
           </tr>
           <tr>
             <td>
-              <code class="code">.mw5</code>
+              <code class="code mr2">.mw5</code>
             </td>
             <td>
-              <div class="mw5 bg-black-10 pv2 oh">
+              <div class="mw5 bg-black-10 pa2 mv1">
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+                tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+                vero eos et accusam et justo duo dolores et ea rebum.
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code class="code mr2">.mw6</code>
+            </td>
+            <td>
+              <div class="mw6 bg-black-10 pa2 mv1">
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
                 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
                 vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
@@ -161,10 +173,36 @@ Media Query Extensions:
           </tr>
           <tr>
             <td>
-              <code class="code">.mw6</code>
+              <code class="code mr2">.mw7</code>
             </td>
             <td>
-              <div class="mw6 bg-black-10 pv2 oh">
+              <div class="mw7 bg-black-10 pa2 mv1">
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+                tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+                vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                no sea takimata sanctus est Lorem ipsum dolor sit amet.
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code class="code mr2">.mw8</code>
+            </td>
+            <td>
+              <div class="mw8 bg-black-10 pa2 mv1">
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+                tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+                vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                no sea takimata sanctus est Lorem ipsum dolor sit amet.
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code class="code mr2">.mw9</code>
+            </td>
+            <td>
+              <div class="mw9 bg-black-10 pa2 mv1">
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
                 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
                 vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
@@ -175,8 +213,8 @@ Media Query Extensions:
         </table>
         <h3 class="f5 book pt4 caps">Max Width Percentages</h3>
         <div class="bg-black-10 w-100">
-          <div class="mw-100 bg-black-10 mb3">
-            <code class="code">mw-100</code>
+          <div class="mw-100 bg-black-10">
+            <code class="code db pa2">mw-100</code>
           </div>
         </div>
         <div class="mt5 cf">

--- a/docs/layout/max-widths/index.html
+++ b/docs/layout/max-widths/index.html
@@ -92,18 +92,9 @@ Modifiers
   7  = 7th step in width scale
   8  = 8th step in width scale
   9  = 9th step in width scale
-  10 = 10th step in width scale
 
-  -25   = literal value 10%
-  -50   = literal value 20%
-  -75   = literal value 25%
   -100  = literal value 33%
-
   -none  = none
-  -max   = max-content
-  -min   = min-content
-  -fit   = fit-content
-  -fill  = fill-available
 
 Media Query Extensions:
   -ns = not-small

--- a/src/templates/docs/max-widths/index.html
+++ b/src/templates/docs/max-widths/index.html
@@ -72,50 +72,62 @@ Media Query Extensions:
         <table border="0" cellspacing="5" cellpadding="5">
           <tr>
             <td>
-              <code class="code">.mw1</code>
+              <code class="code mr2">.mw1</code>
             </td>
             <td>
-              <div class="mw1 bg-black-10 pv2 oh">
+              <div class="mw1 bg-black-10 pa2 mv1">
                 Lorem
               </div>
             </td>
           </tr>
           <tr>
             <td>
-              <code class="code">.mw2</code>
+              <code class="code mr2">.mw2</code>
             </td>
             <td>
-              <div class="mw2 bg-black-10 pv2 oh">
+              <div class="mw2 bg-black-10 pa2 mv1">
                 Lorem
               </div>
             </td>
           </tr>
           <tr>
             <td>
-              <code class="code">.mw3</code>
+              <code class="code mr2">.mw3</code>
             </td>
             <td>
-              <div class="mw3 bg-black-10 pv2 oh">
+              <div class="mw3 bg-black-10 pa2 mv1">
                 Lorem ipsum dolor sit amet, consetetur sadipscing
               </div>
             </td>
           </tr>
           <tr>
             <td>
-              <code class="code">.mw4</code>
+              <code class="code mr2">.mw4</code>
             </td>
             <td>
-              <div class="mw4 bg-black-10 pv2 oh">
+              <div class="mw4 bg-black-10 pa2 mv1">
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod.
               </div>
             </td>
           </tr>
           <tr>
             <td>
-              <code class="code">.mw5</code>
+              <code class="code mr2">.mw5</code>
             </td>
             <td>
-              <div class="mw5 bg-black-10 pv2 oh">
+              <div class="mw5 bg-black-10 pa2 mv1">
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+                tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+                vero eos et accusam et justo duo dolores et ea rebum.
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code class="code mr2">.mw6</code>
+            </td>
+            <td>
+              <div class="mw6 bg-black-10 pa2 mv1">
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
                 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
                 vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
@@ -125,10 +137,36 @@ Media Query Extensions:
           </tr>
           <tr>
             <td>
-              <code class="code">.mw6</code>
+              <code class="code mr2">.mw7</code>
             </td>
             <td>
-              <div class="mw6 bg-black-10 pv2 oh">
+              <div class="mw7 bg-black-10 pa2 mv1">
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+                tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+                vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                no sea takimata sanctus est Lorem ipsum dolor sit amet.
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code class="code mr2">.mw8</code>
+            </td>
+            <td>
+              <div class="mw8 bg-black-10 pa2 mv1">
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+                tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+                vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                no sea takimata sanctus est Lorem ipsum dolor sit amet.
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code class="code mr2">.mw9</code>
+            </td>
+            <td>
+              <div class="mw9 bg-black-10 pa2 mv1">
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
                 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
                 vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
@@ -139,8 +177,8 @@ Media Query Extensions:
         </table>
         <h3 class="f5 book pt4 caps">Max Width Percentages</h3>
         <div class="bg-black-10 w-100">
-          <div class="mw-100 bg-black-10 mb3">
-            <code class="code">mw-100</code>
+          <div class="mw-100 bg-black-10">
+            <code class="code db pa2">mw-100</code>
           </div>
         </div>
         <div class="mt5 cf">

--- a/src/templates/docs/max-widths/index.html
+++ b/src/templates/docs/max-widths/index.html
@@ -56,18 +56,9 @@ Modifiers
   7  = 7th step in width scale
   8  = 8th step in width scale
   9  = 9th step in width scale
-  10 = 10th step in width scale
 
-  -25   = literal value 10%
-  -50   = literal value 20%
-  -75   = literal value 25%
   -100  = literal value 33%
-
   -none  = none
-  -max   = max-content
-  -min   = min-content
-  -fit   = fit-content
-  -fill  = fill-available
 
 Media Query Extensions:
   -ns = not-small


### PR DESCRIPTION
- Update class name structure
  - Min/max/fit/fill classes, `.mw10`, and 25/50/75% classes don't exist
- Add examples for `.mw7`, `.mw8`, and `.mw9` (oddly the demo table only went 1–6)
- Better whitespace in the table
  - Space between the class name and example block
  - Padding in the example block around text
  - Padding in the `.mw-100` block around text

Ideally these would be separate PRs, and I could separate them if there are any issues, but... :wink: