### PR TITLE
Homepage improvements

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,9 +44,7 @@
     </header>
 
     <main>
-      <div class="ph3 ph5-ns">
-        <h1 class="f4">Docs</h1>
-      </div>
+      <h1 class="f4 ph3 ph5-ns mt5">Docs</h1>
       <div class="ph3 ph5-ns pt3 pb5">
   <section>
     <h2 class="f6 fw7 ttu tracked">Elements</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,15 +6,14 @@
     </title>
     <meta name="description" content="CSS">
     <meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=Edge">
-<meta name="author" content="@mrmrs">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="/css/tachyons.min.css">
-<style>
-  .blue { color: #0074D9; }
-  .bg-blue { background-color: #0074D9; }
-</style>
-
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <meta name="author" content="@mrmrs">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/css/tachyons.min.css">
+    <style>
+      .blue { color: #0074D9; }
+      .bg-blue { background-color: #0074D9; }
+    </style>
   </head>
   <body class="w-100 sans-serif">
     <header class="w-100 pa3 ph5-ns bg-near-white">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,32 +17,31 @@
   </head>
   <body class="w-100 sans-serif">
     <header class="w-100 pa3 ph5-ns bg-near-white">
-  <div class="dt w-100">
-    <div class="dtc v-mid tl w-50">
-      <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
-        Tachyons
-        <div class="dib">
-          <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.12</small>
+      <div class="dt w-100">
+        <div class="dtc v-mid tl w-50">
+          <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
+            Tachyons
+            <div class="dib">
+              <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.12</small>
+            </div>
+          </a>
         </div>
-      </a>
-    </div>
-    <div class="db dtc v-mid w-100 tr">
-
-      <a title="Documentation" href="/docs/"
-         class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
-        Docs
-      </a>
-      <a title="Components" href="/components/"
-         class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
-        Components
-      </a>
-      <a title="Tachyons on GitHub" href="http://github.com/mrmrs/tachyons/"
-         class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dn dib-ns">
-        GitHub
-      </a>
-    </div>
-  </div>
-</header>
+        <nav class="db dtc v-mid w-100 tr">
+          <a title="Documentation" href="/docs/"
+            class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+            Docs
+          </a>
+          <a title="Components" href="/components/"
+            class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+            Components
+          </a>
+          <a title="Tachyons on GitHub" href="http://github.com/mrmrs/tachyons/"
+            class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dn dib-ns">
+            GitHub
+          </a>
+        </nav>
+      </div>
+    </header>
 
     <main>
       <div class="ph3 ph5-ns">

--- a/index.html
+++ b/index.html
@@ -47,11 +47,11 @@
 
     <main class="w-100">
       <section class="bt b--black-10 bg-black-0125 w-100 pv5 pv6-ns">
-<article class="ph3 ph5-ns">
-  <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=star&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
-  <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=fork&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
-</article>
-      <div class="ph3 ph5-ns pb3 pt4">
+      <article class="ph3 ph5-ns">
+        <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=star&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=fork&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+      </article>
+      <article class="ph3 ph5-ns pb3 pt4">
         <h1 class="f4 f3-ns  lh-title measure">
           Tachyons was built for designing.
         </h1>
@@ -63,21 +63,21 @@
           ui component. By learning the composable building blocks in tachyons, you
           can quickly start to build out interfaces while writing little to no css.
         </p>
-      </div>
-          <article class="ph3 ph5-ns mb4 mb5-ns">
-            <h1>Getting Started</h1>
-            <p class="measure lh-copy">
-              Copy the line of code below and paste it in the head of the html file(s) you want to include tachyons in.
-            </p>
-<pre class="pre black-70" style="overflow: auto"><code class="code f6 dib pa2 bg-near-white" style="font-size: 14px;">&lt;link rel="stylesheet" href="https://npmcdn.com/tachyons@4.0.0-beta.12/css/tachyons.min.css"&gt;</code></pre>
-<p class="mt4"><b>or</b> install via npm</p>
-<pre class="pre black-70" style="overflow: auto"><code class="code f6 dib pa2 bg-near-white" style="font-size: 14px;">npm install --save-dev tachyons@4.0.0-beta.12</code></pre>
-<p class="mt4"><b>or</b> grab all the source files and build+develop locally</p>
-<pre class="pre black-70" style="overflow: auto"><code class="code f6 dib pa2 bg-near-white" style="font-size: 14px;">git clone git@github.com:tachyons-css/tachyons.git
+      </article>
+      <article class="ph3 ph5-ns mb4 mb5-ns">
+        <h1>Getting Started</h1>
+        <p class="measure lh-copy">
+          Copy the line of code below and paste it in the head of the html file(s) you want to include tachyons in.
+        </p>
+        <pre class="pre black-70" style="overflow: auto"><code class="code f6 dib pa2 bg-near-white" style="font-size: 14px;">&lt;link rel="stylesheet" href="https://npmcdn.com/tachyons@4.0.0-beta.12/css/tachyons.min.css"&gt;</code></pre>
+        <p class="mt4"><b>or</b> install via npm</p>
+        <pre class="pre black-70" style="overflow: auto"><code class="code f6 dib pa2 bg-near-white" style="font-size: 14px;">npm install --save-dev tachyons@4.0.0-beta.12</code></pre>
+        <p class="mt4"><b>or</b> grab all the source files and build+develop locally</p>
+        <pre class="pre black-70" style="overflow: auto"><code class="code f6 dib pa2 bg-near-white" style="font-size: 14px;">git clone git@github.com:tachyons-css/tachyons.git
 cd tachyons
 npm install &amp;&amp; npm build
-</code></pre>
-          </article>
+        </code></pre>
+      </article>
           <div class="ph3 ph5-ns tl tl-ns bt b--light-gray pv3 pv5-ns">
             <h1>Principles</h1>
             <section class="list pln lh-copy mt0">
@@ -328,7 +328,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
           </div>
           <code class="dib mb4 ba b--light-gray f6 ph2 pv3" style="background-color: #d1ffff;">npm install --save-dev tachyons-module-name</code>
         </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-background-size">tachyons-background-size</a>
             <div>
@@ -337,7 +337,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-background-size">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-base">tachyons-base</a>
             <div>
@@ -346,7 +346,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-base">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-border-colors">tachyons-border-colors</a>
             <div>
@@ -355,7 +355,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-border-colors">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-border-radius">tachyons-border-radius</a>
             <div>
@@ -364,7 +364,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-border-radius">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-border-style">tachyons-border-style</a>
             <div>
@@ -373,7 +373,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-border-style">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-border-widths">tachyons-border-widths</a>
             <div>
@@ -382,7 +382,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-border-widths">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-borders">tachyons-borders</a>
             <div>
@@ -391,7 +391,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-borders">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-box-sizing">tachyons-box-sizing</a>
             <div>
@@ -400,7 +400,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-box-sizing">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-clears">tachyons-clears</a>
             <div>
@@ -409,7 +409,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-clears">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-colors">tachyons-colors</a>
             <div>
@@ -418,7 +418,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-colors">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-coordinates">tachyons-coordinates</a>
             <div>
@@ -427,7 +427,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-coordinates">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-debug">tachyons-debug</a>
             <div>
@@ -436,7 +436,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-debug">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-display">tachyons-display</a>
             <div>
@@ -445,7 +445,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-display">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-display-verbose">tachyons-display-verbose</a>
             <div>
@@ -454,7 +454,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-display-verbose">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-floats">tachyons-floats</a>
             <div>
@@ -463,7 +463,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-floats">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-font-family">tachyons-font-family</a>
             <div>
@@ -472,7 +472,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-font-family">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-font-style">tachyons-font-style</a>
             <div>
@@ -481,7 +481,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-font-style">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-font-weight">tachyons-font-weight</a>
             <div>
@@ -490,7 +490,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-font-weight">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-forms">tachyons-forms</a>
             <div>
@@ -499,7 +499,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-forms">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-heights">tachyons-heights</a>
             <div>
@@ -508,7 +508,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-heights">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-hovers">tachyons-hovers</a>
             <div>
@@ -517,7 +517,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-hovers">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-images">tachyons-images</a>
             <div>
@@ -526,7 +526,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-images">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-letter-spacing">tachyons-letter-spacing</a>
             <div>
@@ -535,7 +535,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-letter-spacing">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-line-height">tachyons-line-height</a>
             <div>
@@ -544,7 +544,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-line-height">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-links">tachyons-links</a>
             <div>
@@ -553,7 +553,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-links">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-lists">tachyons-lists</a>
             <div>
@@ -562,7 +562,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-lists">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-max-widths">tachyons-max-widths</a>
             <div>
@@ -571,7 +571,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-max-widths">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-opacity">tachyons-opacity</a>
             <div>
@@ -580,7 +580,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-opacity">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-outlines">tachyons-outlines</a>
             <div>
@@ -589,7 +589,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-outlines">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-overflow">tachyons-overflow</a>
             <div>
@@ -598,7 +598,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-overflow">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-position">tachyons-position</a>
             <div>
@@ -607,7 +607,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-position">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-spacing">tachyons-spacing</a>
             <div>
@@ -616,7 +616,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-spacing">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-text-align">tachyons-text-align</a>
             <div>
@@ -625,7 +625,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-text-align">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-text-decoration">tachyons-text-decoration</a>
             <div>
@@ -634,7 +634,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-text-decoration">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-text-transform">tachyons-text-transform</a>
             <div>
@@ -643,7 +643,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-text-transform">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-type-scale">tachyons-type-scale</a>
             <div>
@@ -652,7 +652,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-type-scale">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-typography">tachyons-typography</a>
             <div>
@@ -661,7 +661,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-typography">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-utilities">tachyons-utilities</a>
             <div>
@@ -670,7 +670,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-utilities">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-vertical-align">tachyons-vertical-align</a>
             <div>
@@ -679,7 +679,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-vertical-align">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-visibility">tachyons-visibility</a>
             <div>
@@ -688,7 +688,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-visibility">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-white-space">tachyons-white-space</a>
             <div>
@@ -697,7 +697,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-white-space">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-widths">tachyons-widths</a>
             <div>
@@ -706,7 +706,7 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-widths">View on GitHub</a>
             </div>
           </div>
-        
+
           <div class="mb3 fl w-100 w-50-m w-33-l">
             <a class="db f4 link mb1 dim near-black b" href="http://npmjs.com/package/tachyons-word-break">tachyons-word-break</a>
             <div>
@@ -715,58 +715,54 @@ I’ve found extremely low-level “frameworks” like BassCSS and Tachyons usef
               <a class="link dim near-black dib ml2 f6" href="http://github.com/tachyons-css/tachyons-word-break">View on GitHub</a>
             </div>
           </div>
-        
-
-        
       </section>
     </main>
     <footer class="bg-near-white mid-gray ph3 ph5-ns pv5 pv6-ns bt b--black-10">
-  <a href="https://twitter.com/intent/tweet?text=Tachyons: Functional CSS for Humans.&url=http://tachyons.io" target="_blank" class="dn mb3 twitter bg-white link dim br2 ph2 pb1 pt0 lh-solid" style="background-color: #55acee;">
-    <svg class="geomicon dib v-mid" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="16" height="16" fill="#fff">
-      <path d="M2 4 C6 8 10 12 15 11 A6 6 0 0 1 22 4 A6 6 0 0 1 26 6 A8 8 0 0 0 31 4 A8 8 0 0 1 28 8 A8 8 0 0 0 32 7 A8 8 0 0 1 28 11 A18 18 0 0 1 10 30 A18 18 0 0 1 0 27 A12 12 0 0 0 8 24 A8 8 0 0 1 3 20 A8 8 0 0 0 6 19.5 A8 8 0 0 1 0 12 A8 8 0 0 0 3 13 A8 8 0 0 1 2 4"/>
-    </svg>
-    <span class="dib v-mid white fw6" style="font-size: 12px;">Tweet</span>
-  </a>
-  <div class="mb4">
-    <a class="black-70 link dim b dib mr3" href="/" title="Home">
-      Home
-    </a>
-    <a class="black-70 link dim b dib mr3" href="/docs" title="Docs">
-      Docs
-    </a>
-    <a class="black-70 link dim b dib mr3" href="/components/" title="Components">
-      Components
-    </a>
-  </div>
-  <article>
-    <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=star&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
-    <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=fork&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
-  </article>
-  <div class="mt4">
-    <a class="black-70 link dim b dib mr3 pv2" href="http://tachyons-slack-invite.herokuapp.com" title="Join our Slack Channel">
-      Join our Slack Channel
-    </a>
-    <a class="black-70 link dim b dib mr3 pv2" href="https://github.com/tachyons-css/tachyons/issues" title="File a bug, request a feature, ask a question!">
-      Open an Issue
-    </a>
-    <a class="black-70 link dim b dib mr3 pv2" href="https://github.com/tachyons-css" title="Tachyons-css on GitHub">
-      GitHub
-    </a>
-  </div>
-  <p class="measure copy lh-copy">
-    Have a question? Need help? Feel free to open an issue on GitHub or ask a
-    question in our slack channel. We're here to try and help make designing in
-    the browser fun.
-  </p>
-  <small class="f6 measure db lh-copy mt5">
-    A tachyon /ˈtæki.ɒn/ or tachyonic particle is a hypothetical particle
-    that always moves faster than light.
-    The word comes from the Greek:
-    <br> <br>
-    ταχύς or tachys, meaning "swift, quick, fast, rapid"
-  </small>
-</footer>
-
+      <a href="https://twitter.com/intent/tweet?text=Tachyons: Functional CSS for Humans.&url=http://tachyons.io" target="_blank" class="dn mb3 twitter bg-white link dim br2 ph2 pb1 pt0 lh-solid" style="background-color: #55acee;">
+        <svg class="geomicon dib v-mid" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="16" height="16" fill="#fff">
+          <path d="M2 4 C6 8 10 12 15 11 A6 6 0 0 1 22 4 A6 6 0 0 1 26 6 A8 8 0 0 0 31 4 A8 8 0 0 1 28 8 A8 8 0 0 0 32 7 A8 8 0 0 1 28 11 A18 18 0 0 1 10 30 A18 18 0 0 1 0 27 A12 12 0 0 0 8 24 A8 8 0 0 1 3 20 A8 8 0 0 0 6 19.5 A8 8 0 0 1 0 12 A8 8 0 0 0 3 13 A8 8 0 0 1 2 4"/>
+        </svg>
+        <span class="dib v-mid white fw6" style="font-size: 12px;">Tweet</span>
+      </a>
+      <div class="mb4">
+        <a class="black-70 link dim b dib mr3" href="/" title="Home">
+          Home
+        </a>
+        <a class="black-70 link dim b dib mr3" href="/docs" title="Docs">
+          Docs
+        </a>
+        <a class="black-70 link dim b dib mr3" href="/components/" title="Components">
+          Components
+        </a>
+      </div>
+      <article>
+        <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=star&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=fork&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+      </article>
+      <div class="mt4">
+        <a class="black-70 link dim b dib mr3 pv2" href="http://tachyons-slack-invite.herokuapp.com" title="Join our Slack Channel">
+          Join our Slack Channel
+        </a>
+        <a class="black-70 link dim b dib mr3 pv2" href="https://github.com/tachyons-css/tachyons/issues" title="File a bug, request a feature, ask a question!">
+          Open an Issue
+        </a>
+        <a class="black-70 link dim b dib mr3 pv2" href="https://github.com/tachyons-css" title="Tachyons-css on GitHub">
+          GitHub
+        </a>
+      </div>
+      <p class="measure copy lh-copy">
+        Have a question? Need help? Feel free to open an issue on GitHub or ask a
+        question in our slack channel. We're here to try and help make designing in
+        the browser fun.
+      </p>
+      <small class="f6 measure db lh-copy mt5">
+        A tachyon /ˈtæki.ɒn/ or tachyonic particle is a hypothetical particle
+        that always moves faster than light.
+        The word comes from the Greek:
+        <br> <br>
+        ταχύς or tachys, meaning "swift, quick, fast, rapid"
+      </small>
+    </footer>
 
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/index.html
+++ b/index.html
@@ -6,15 +6,14 @@
     </title>
     <meta name="description" content="Simple CSS">
     <meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=Edge">
-<meta name="author" content="@mrmrs">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="/css/tachyons.min.css">
-<style>
-  .blue { color: #0074D9; }
-  .bg-blue { background-color: #0074D9; }
-</style>
-
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <meta name="author" content="@mrmrs">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/css/tachyons.min.css">
+    <style>
+      .blue { color: #0074D9; }
+      .bg-blue { background-color: #0074D9; }
+    </style>
   </head>
   <body class="w-100 sans-serif">
     <header class="w-100 pa3 ph5-ns bg-near-white">

--- a/index.html
+++ b/index.html
@@ -46,16 +46,16 @@
     </header>
 
     <main class="w-100">
-      <section class="bt b--black-10 bg-black-0125 w-100 pv5 pv6-ns">
+      <section class="bt b--black-10 bg-black-0125 w-100 pt4 pt5-ns pb5 pb6-ns">
       <article class="ph3 ph5-ns">
         <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=star&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
         <iframe src="https://ghbtns.com/github-btn.html?user=tachyons-css&repo=tachyons&type=fork&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
       </article>
       <article class="ph3 ph5-ns pb3 pt4">
-        <h1 class="f4 f3-ns  lh-title measure">
+        <h1 class="f3 f2-ns lh-title measure">
           Tachyons was built for designing.
         </h1>
-        <p class="f5 f4-ns b measure lh-copy">Create fast loading, highly readable, and
+        <p class="f5 f4-ns fw6 measure lh-copy">Create fast loading, highly readable, and
           100% responsive interfaces with as little css as possible.</p>
         <p class="measure f5 f4-ns lh-copy">
           Modules can be altered, extended, or changed to meet your design needs.

--- a/index.html
+++ b/index.html
@@ -17,32 +17,33 @@
   </head>
   <body class="w-100 sans-serif">
     <header class="w-100 pa3 ph5-ns bg-near-white">
-  <div class="dt w-100">
-    <div class="dtc v-mid tl w-50">
-      <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
-        Tachyons
-        <div class="dib">
-          <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.12</small>
+      <div class="dt w-100">
+        <div class="dtc v-mid tl w-50">
+          <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim"
+          title="Home">
+            Tachyons
+            <div class="dib">
+              <small class="nowrap f6 mt2 mt3-ns pr2 black-70
+              fw2">v4.0.0-beta.12</small>
+            </div>
+          </a>
         </div>
-      </a>
-    </div>
-    <div class="db dtc v-mid w-100 tr">
-
-      <a title="Documentation" href="/docs/"
-         class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
-        Docs
-      </a>
-      <a title="Components" href="/components/"
-         class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
-        Components
-      </a>
-      <a title="Tachyons on GitHub" href="http://github.com/mrmrs/tachyons/"
-         class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dn dib-ns">
-        GitHub
-      </a>
-    </div>
-  </div>
-</header>
+        <nav class="db dtc v-mid w-100 tr">
+          <a title="Documentation" href="/docs/"
+            class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+            Docs
+          </a>
+          <a title="Components" href="/components/"
+            class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+            Components
+          </a>
+          <a title="Tachyons on GitHub" href="http://github.com/mrmrs/tachyons/"
+            class="f6 fw6 dim link black-70 mr1 mr3-m mr4-l dn dib-ns">
+            GitHub
+          </a>
+        </nav>
+      </div>
+    </header>
 
     <main class="w-100">
       <section class="bt b--black-10 bg-black-0125 w-100 pv5 pv6-ns">


### PR DESCRIPTION
- On the homepage, I've bumped up the font size of the header, making it clearer, while reducing the whitespace at the top (which looked odd on mobile)
- On the docs index page, I've added a little extra whitespace at the top (without the unnecessary container element)
- In the header, I'm using a `<nav>` element around the links (instead of just a div)
- Most of the changes here are fixing code whitespace (trailing spaces, indenting, etc)

Homepage before:
<img width="1228" alt="screenshot 2016-03-25 13 15 33" src="https://cloud.githubusercontent.com/assets/5074763/14049505/14091d28-f28c-11e5-8746-cbf138693ba5.png">

Homepage after:
<img width="1231" alt="screenshot 2016-03-25 13 15 40" src="https://cloud.githubusercontent.com/assets/5074763/14049510/180fdd26-f28c-11e5-86e0-16333281ed82.png">
