### PR TITLE
Fix font style source code filename

### DIFF
--- a/docs/typography/font-style/index.html
+++ b/docs/typography/font-style/index.html
@@ -105,7 +105,7 @@
       </div>
       <section class="bg-near-white black-70 pt4 pb5">
         <header class="ph3 ph5-ns pt4">
-          <kbd class="yellow">src/_font-weights.css</kbd>
+          <kbd class="yellow">src/_font-style.css</kbd>
         </header>
 <pre class="ph3 ph5-ns">
 <code class="code" style="font-size: .75rem;">

--- a/src/templates/docs/font-style/index.html
+++ b/src/templates/docs/font-style/index.html
@@ -72,7 +72,7 @@
       </div>
       <section class="bg-near-white black-70 pt4 pb5">
         <header class="ph3 ph5-ns pt4">
-          <kbd class="yellow">src/_font-weights.css</kbd>
+          <kbd class="yellow">src/_font-style.css</kbd>
         </header>
 <pre class="ph3 ph5-ns">
 <code class="code" style="font-size: .75rem;">


### PR DESCRIPTION
Noticed a little issue today: the font styles docs say the file path is `src/_font-weights.css`, not `src/_font-style.css`.