### PR TITLE
More consistent example labels

### DIFF
--- a/docs/typography/font-style/index.html
+++ b/docs/typography/font-style/index.html
@@ -75,16 +75,12 @@
       </article>
       <div class="ph3 ph5-ns pt4 pb5">
         <h2 class="f3 bold">Examples</h2>
-        <code class="f6">
-          &lt;p class="i"&gt;&lt;/p&gt;
-        </code>
+        <h3 class="f5 pt4">Italics</h3>
         <p class="i mb4">
           Readers want what is important to be clearly laid out; they will not read
           what is too troublesome.
         </p>
-        <code class="f6">
-          &lt;p class="fs-normal"&gt;&lt;/p&gt;
-        </code>
+        <h3 class="f5 pt2">Normal</h3>
         <p class="fs-normal">
           A quote from Jan Tschichold about typography.
         </p>

--- a/docs/typography/text-align/index.html
+++ b/docs/typography/text-align/index.html
@@ -75,16 +75,16 @@
         </p>
       </article>
       <div class="ph3 ph5-ns pt4 pb5">
-        <h2 class="f3 b">Examples</h2>
-        <h3 class="f5 fw4 pt4 caps">Text Align Left</h3>
+        <h2 class="f3">Examples</h2>
+        <h3 class="f5 pt4">Text Align Left</h3>
         <p class="measure bg-black-10">
           Aligned Left
         </p>
-        <h3 class="f5 fw4 pt4 caps">Text Align Right</h3>
+        <h3 class="f5 pt4">Text Align Right</h3>
         <p class="tr measure bg-black-10">
           Aligned Right
         </p>
-        <h3 class="f5 fw4 pt4 caps">Text Align Center</h3>
+        <h3 class="f5 pt4">Text Align Center</h3>
         <p class="tc measure bg-black-10">
           Aligned to the center
         </p>

--- a/docs/typography/text-decoration/index.html
+++ b/docs/typography/text-decoration/index.html
@@ -73,16 +73,16 @@
       </article>
       <div class="ph3 ph5-ns pt4 pb5">
         <h2 class="f3 b">Examples</h2>
-        <h3 class="f5 fw4 pt4 ttu tracked">Text Decoration None</h3>
+        <h3 class="f5 pt4">Text Decoration None</h3>
         <a href="#" class="no-underline">Text Decoration None on a Link</a>
-        <h3 class="f5 fw4 pt4 ttu tracked">Text Decoration Underline</h3>
+        <h3 class="f5 pt4">Text Decoration Underline</h3>
         <p class="underline measure">
-      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
-      tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
-      vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
-      no sea takimata sanctus est Lorem ipsum dolor sit amet.
-      </p>
-        <h3 class="f5 fw4 pt4 ttu tracked">Text Decoration Strikethrough</h3>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+        tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+        vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+        no sea takimata sanctus est Lorem ipsum dolor sit amet.
+        </p>
+        <h3 class="f5 pt4">Text Decoration Strikethrough</h3>
         <p class="strike">Lorem ipsum dolor sit amet</p>
         <div class="mt5 cf">
           <div class="dib mr4">

--- a/src/templates/docs/font-style/index.html
+++ b/src/templates/docs/font-style/index.html
@@ -42,16 +42,12 @@
       </article>
       <div class="ph3 ph5-ns pt4 pb5">
         <h2 class="f3 bold">Examples</h2>
-        <code class="f6">
-          &lt;p class="i"&gt;&lt;/p&gt;
-        </code>
+        <h3 class="f5 pt4">Italics</h3>
         <p class="i mb4">
           Readers want what is important to be clearly laid out; they will not read
           what is too troublesome.
         </p>
-        <code class="f6">
-          &lt;p class="fs-normal"&gt;&lt;/p&gt;
-        </code>
+        <h3 class="f5 pt2">Normal</h3>
         <p class="fs-normal">
           A quote from Jan Tschichold about typography.
         </p>

--- a/src/templates/docs/text-align/index.html
+++ b/src/templates/docs/text-align/index.html
@@ -42,16 +42,16 @@
         </p>
       </article>
       <div class="ph3 ph5-ns pt4 pb5">
-        <h2 class="f3 b">Examples</h2>
-        <h3 class="f5 fw4 pt4 caps">Text Align Left</h3>
+        <h2 class="f3">Examples</h2>
+        <h3 class="f5 pt4">Text Align Left</h3>
         <p class="measure bg-black-10">
           Aligned Left
         </p>
-        <h3 class="f5 fw4 pt4 caps">Text Align Right</h3>
+        <h3 class="f5 pt4">Text Align Right</h3>
         <p class="tr measure bg-black-10">
           Aligned Right
         </p>
-        <h3 class="f5 fw4 pt4 caps">Text Align Center</h3>
+        <h3 class="f5 pt4">Text Align Center</h3>
         <p class="tc measure bg-black-10">
           Aligned to the center
         </p>

--- a/src/templates/docs/text-decoration/index.html
+++ b/src/templates/docs/text-decoration/index.html
@@ -40,16 +40,16 @@
       </article>
       <div class="ph3 ph5-ns pt4 pb5">
         <h2 class="f3 b">Examples</h2>
-        <h3 class="f5 fw4 pt4 ttu tracked">Text Decoration None</h3>
+        <h3 class="f5 pt4">Text Decoration None</h3>
         <a href="#" class="no-underline">Text Decoration None on a Link</a>
-        <h3 class="f5 fw4 pt4 ttu tracked">Text Decoration Underline</h3>
+        <h3 class="f5 pt4">Text Decoration Underline</h3>
         <p class="underline measure">
-      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
-      tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
-      vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
-      no sea takimata sanctus est Lorem ipsum dolor sit amet.
-      </p>
-        <h3 class="f5 fw4 pt4 ttu tracked">Text Decoration Strikethrough</h3>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+        tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+        vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+        no sea takimata sanctus est Lorem ipsum dolor sit amet.
+        </p>
+        <h3 class="f5 pt4">Text Decoration Strikethrough</h3>
         <p class="strike">Lorem ipsum dolor sit amet</p>
         <div class="mt5 cf">
           <div class="dib mr4">


### PR DESCRIPTION
Just looking through a few typography docs pages, we've got a number of different styles for example names. I think the bold text works really nicely (as opposed to tracked caps or regular text), and `.pt4`, so I've applied that to a few pages in an effort to get more standardization (one of the major but necessary problems with HTML docs).

<img width="518" alt="screenshot 2016-04-25 13 45 28" src="https://cloud.githubusercontent.com/assets/5074763/14793218/00236e6c-0aec-11e6-8bd6-1037f5d3c8d6.png">

<img width="516" alt="screenshot 2016-04-25 13 45 34" src="https://cloud.githubusercontent.com/assets/5074763/14793221/0182a32c-0aec-11e6-810c-56af28de419c.png">
