### PR TITLE
Removes `.input-invisible` from docs

### DIFF
--- a/docs/debug/index.html
+++ b/docs/debug/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/elements/forms/index.html
+++ b/docs/elements/forms/index.html
@@ -23,7 +23,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -96,7 +96,7 @@
       </div>
       <section class="bg-near-white black-70 pt4 pb5">
         <header class="ph3 ph5-ns pt4">
-          <kbd class="yellow">src/_forms.css</kbd>
+          <kbd class="yellow">src/_links.css</kbd>
         </header>
 <pre class="ph3 ph5-ns">
 <code class="code" style="font-size: .75rem;">
@@ -109,11 +109,6 @@
 .input-reset {
   -webkit-appearance: none;
   -moz-appearance: none;
-}
-
-.input-invisible {
-  outline: 0;
-  border: 0;
 }
 
 

--- a/docs/elements/images/index.html
+++ b/docs/elements/images/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/elements/links/index.html
+++ b/docs/elements/links/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/elements/lists/index.html
+++ b/docs/elements/lists/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/layout/box-sizing/index.html
+++ b/docs/layout/box-sizing/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/layout/clearfix/index.html
+++ b/docs/layout/clearfix/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -45,16 +45,16 @@
     <main class="">
       <article class="bg-near-white bt b--black-10 pa3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-clears</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v2.0.4</span>
-        <span class="f4 b dib pl0 ml0 mr4">92 B</span>
+        <span class="f4 b dib pl0 ml0 mr4">v2.2.0</span>
+        <span class="f4 b dib pl0 ml0 mr4">200 B</span>
         <div>
           <dl class="dib mr4 mt0">
             <dt class="f6 db">Declarations </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">4</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">20</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Selectors </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">4</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">20</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Max. Specificity Score </dt>
@@ -62,7 +62,7 @@
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Size of Avg. Rule </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">1.3333333333333333</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">1.0526315789473684</dd>
           </dl>
         </div>
         <p class="measure f4 f3-ns lh-copy">

--- a/docs/layout/display/index.html
+++ b/docs/layout/display/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/layout/floats/index.html
+++ b/docs/layout/floats/index.html
@@ -23,7 +23,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/layout/heights/index.html
+++ b/docs/layout/heights/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -45,16 +45,16 @@
     <main class="">
       <article class="bg-near-white bt b--black-10 pa3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-heights</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v4.1.0</span>
-        <span class="f4 b dib pl0 ml0 mr4">234 B</span>
+        <span class="f4 b dib pl0 ml0 mr4">v4.1.3</span>
+        <span class="f4 b dib pl0 ml0 mr4">254 B</span>
         <div>
           <dl class="dib mr4 mt0">
             <dt class="f6 db">Declarations </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">36</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">44</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Selectors </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">36</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">44</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Max. Specificity Score </dt>

--- a/docs/layout/max-widths/index.html
+++ b/docs/layout/max-widths/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/layout/position/index.html
+++ b/docs/layout/position/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/layout/spacing/index.html
+++ b/docs/layout/spacing/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -45,16 +45,16 @@
     <main class="">
       <article class="bg-near-white bt b--black-10 pa3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-spacing</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v5.0.4</span>
-        <span class="f4 b dib pl0 ml0 mr4">1.7 KB</span>
+        <span class="f4 b dib pl0 ml0 mr4">v5.0.9</span>
+        <span class="f4 b dib pl0 ml0 mr4">1.71 KB</span>
         <div>
           <dl class="dib mr4 mt0">
             <dt class="f6 db">Declarations </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">572</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">576</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Selectors </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">446</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">448</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Max. Specificity Score </dt>
@@ -62,7 +62,7 @@
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Size of Avg. Rule </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">1.2825112107623318</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">1.2857142857142858</dd>
           </dl>
         </div>
         <p class="measure f4 f3-ns lh-copy">

--- a/docs/layout/widths/index.html
+++ b/docs/layout/widths/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/themes/background-size/index.html
+++ b/docs/themes/background-size/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -45,7 +45,7 @@
     <main>
       <article class="bg-near-white bt b--black-10 ph3 pt3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-background-size</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v3.0.2</span>
+        <span class="f4 b dib pl0 ml0 mr4">v3.0.3</span>
         <span class="f4 b dib pl0 ml0 mr4">139 B</span>
         <div>
           <dl class="dib mr4 mt0">

--- a/docs/themes/border-radius/index.html
+++ b/docs/themes/border-radius/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/themes/borders/index.html
+++ b/docs/themes/borders/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -45,16 +45,16 @@
     <main class="">
       <article class="bg-near-white bt b--black-10 pa3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-borders</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v2.0.3</span>
-        <span class="f4 b dib pl0 ml0 mr4">208 B</span>
+        <span class="f4 b dib pl0 ml0 mr4">v2.1.0</span>
+        <span class="f4 b dib pl0 ml0 mr4">228 B</span>
         <div>
           <dl class="dib mr4 mt0">
             <dt class="f6 db">Declarations </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">40</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">48</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Selectors </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">20</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">24</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Max. Specificity Score </dt>

--- a/docs/themes/hovers/index.html
+++ b/docs/themes/hovers/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -45,16 +45,16 @@
     <main class="">
       <article class="bg-near-white bt b--black-10 pa3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-hovers</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v2.0.5</span>
-        <span class="f4 b dib pl0 ml0 mr4">149 B</span>
+        <span class="f4 b dib pl0 ml0 mr4">v2.1.0</span>
+        <span class="f4 b dib pl0 ml0 mr4">175 B</span>
         <div>
           <dl class="dib mr4 mt0">
             <dt class="f6 db">Declarations </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">9</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">10</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Selectors </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">11</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">13</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Max. Specificity Score </dt>
@@ -62,7 +62,7 @@
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Size of Avg. Rule </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">1.5</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">1.4285714285714286</dd>
           </dl>
         </div>
         <p class="measure f3 lh-copy">

--- a/docs/themes/skins/index.html
+++ b/docs/themes/skins/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -45,16 +45,16 @@
     <main class="">
       <article class="bg-near-white bt b--black-10 pa3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-skins</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v3.1.1</span>
-        <span class="f4 b dib pl0 ml0 mr4">672 B</span>
+        <span class="f4 b dib pl0 ml0 mr4">v3.1.4</span>
+        <span class="f4 b dib pl0 ml0 mr4">689 B</span>
         <div>
           <dl class="dib mr4 mt0">
             <dt class="f6 db">Declarations </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">96</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">104</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Selectors </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">102</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">104</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Max. Specificity Score </dt>

--- a/docs/typography/font-family/index.html
+++ b/docs/typography/font-family/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -45,8 +45,8 @@
     <main class="">
       <article class="bg-near-white bt b--black-10 pa3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-font-family</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v4.1.1</span>
-        <span class="f4 b dib pl0 ml0 mr4">232 B</span>
+        <span class="f4 b dib pl0 ml0 mr4">v4.1.2</span>
+        <span class="f4 b dib pl0 ml0 mr4">239 B</span>
         <div>
           <dl class="dib mr4 mt0">
             <dt class="f6 db">Declarations </dt>

--- a/docs/typography/font-style/index.html
+++ b/docs/typography/font-style/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/typography/font-weight/index.html
+++ b/docs/typography/font-weight/index.html
@@ -23,7 +23,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/typography/line-height/index.html
+++ b/docs/typography/line-height/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/typography/measure/index.html
+++ b/docs/typography/measure/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>
@@ -45,16 +45,16 @@
     <main>
       <article class="bg-near-white bt b--black-10 pa3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-typography</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v2.1.1</span>
-        <span class="f4 b dib pl0 ml0 mr4">226 B</span>
+        <span class="f4 b dib pl0 ml0 mr4">v2.2.0</span>
+        <span class="f4 b dib pl0 ml0 mr4">245 B</span>
         <div>
           <dl class="dib mr4 mt0">
             <dt class="f6 db">Declarations </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">32</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">36</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Selectors </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">16</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">20</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Max. Specificity Score </dt>
@@ -62,7 +62,7 @@
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Size of Avg. Rule </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">2</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">1.8</dd>
           </dl>
         </div>
         <p class="measure f4 f3-ns lh-copy">

--- a/docs/typography/scale/index.html
+++ b/docs/typography/scale/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/typography/text-align/index.html
+++ b/docs/typography/text-align/index.html
@@ -23,7 +23,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/typography/text-decoration/index.html
+++ b/docs/typography/text-decoration/index.html
@@ -23,7 +23,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/typography/text-transform/index.html
+++ b/docs/typography/text-transform/index.html
@@ -22,7 +22,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/typography/tracking/index.html
+++ b/docs/typography/tracking/index.html
@@ -23,7 +23,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/typography/vertical-align/index.html
+++ b/docs/typography/vertical-align/index.html
@@ -23,7 +23,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/docs/typography/white-space/index.html
+++ b/docs/typography/white-space/index.html
@@ -23,7 +23,7 @@
     <a href="/" class="dib f5 f4-ns fw6 mt0 mb1 link black-70 dim" title="Home">
       Tachyons
       <div class="dib">
-        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.22</small>
+        <small class="nowrap f6 mt2 mt3-ns pr2 black-70 fw2">v4.0.0-beta.27</small>
       </div>
     </a>
   </div>

--- a/src/css/_forms.css
+++ b/src/css/_forms.css
@@ -9,8 +9,3 @@
   -moz-appearance: none;
 }
 
-.input-invisible {
-  outline: 0;
-  border: 0;
-}
-


### PR DESCRIPTION
Commit https://github.com/tachyons-css/tachyons/commit/9a818489ca4ac730cf663a4e7bcc3f7417548c1d seems to have
removed `.input-invisible`, but it's still available in the docs.