### PR TITLE
.mega => .f-5  .mtn => .mt0

### DIFF
--- a/docs/layout/floats/index.html
+++ b/docs/layout/floats/index.html
@@ -104,7 +104,7 @@
         <p class="f3">Originally floats were used to wrap text around images as in the example below.</p>
         <div class="cf">
           <img src="/img/example-1.jpg" class="fl w4 mr3" alt="example 1">
-          <p class="measure mtn">
+          <p class="measure mt0">
             Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
             tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
             vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,

--- a/docs/themes/gradients/index.html
+++ b/docs/themes/gradients/index.html
@@ -14,7 +14,7 @@
   <body class="w-100 sans-serif">
     <header class="bg-dark-gray white pbl">
       <div class="bb b--mid-gray phm phl-ns pvl">
-        <h1 class="f4 ttu mtn heavy tracked"><a class="white link dim" href="/">Tachyons</a></h1>
+        <h1 class="f4 ttu mt0 heavy tracked"><a class="white link dim" href="/">Tachyons</a></h1>
         <h2 class="f4 mvn semibold dib prxs"><a class="lightest-blue link dim" href="/docs/">Docs</a></h2>
         <span class="thin white-40">/</span>
         <h3 class="f4 mvn semibold dib prxs"><a class="lightest-blue link dim" href="/docs/#themes">Themes</a></h3>

--- a/docs/themes/hovers/index.html
+++ b/docs/themes/hovers/index.html
@@ -53,16 +53,16 @@
     <main class="">
       <article class="bg-near-white bt b--black-10 pa3 ph5-ns">
         <h4 class="f4 mv0 fw6 dib mr4">tachyons-hovers</h4>
-        <span class="f4 b dib pl0 ml0 mr4">v2.1.0</span>
-        <span class="f4 b dib pl0 ml0 mr4">175 B</span>
+        <span class="f4 b dib pl0 ml0 mr4">v2.2.0</span>
+        <span class="f4 b dib pl0 ml0 mr4">220 B</span>
         <div>
           <dl class="dib mr4 mt0">
             <dt class="f6 db">Declarations </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">10</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">14</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Selectors </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">13</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">17</dd>
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Max. Specificity Score </dt>
@@ -70,7 +70,7 @@
           </dl>
           <dl class="dib mr4">
             <dt class="f6 db pr2">Size of Avg. Rule </dt>
-            <dd class="db pl0 ml0 f4 f2-ns b">1.4285714285714286</dd>
+            <dd class="db pl0 ml0 f4 f2-ns b">1.2727272727272727</dd>
           </dl>
         </div>
         <p class="measure f3 lh-copy">

--- a/docs/typography/line-height/index.html
+++ b/docs/typography/line-height/index.html
@@ -104,15 +104,15 @@
           no sea takimata sanctus est Lorem ipsum dolor sit amet.
         </p>
         <h3 class="f5 book ptxl ttu">No Applied Title Leading (Default)</h3>
-        <p class="measure ttu mega fw6 mtn">
+        <p class="measure ttu f-5 fw6 mt0">
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr
         </p>
         <h3 class="f5 book ptxl ttu">Title Leading (1.3)</h3>
-        <p class="measure lh-title ttu mega fw6 mtn">
+        <p class="measure lh-title ttu f-5 fw6 mt0">
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr
         </p>
         <h3 class="f5 book ptxl ttu">Solid Leading (1)</h3>
-        <p class="measure lh-solid ttu mega fw6 mtn">
+        <p class="measure lh-solid ttu f-5 fw6 mt0">
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr
         </p>
         <div class="mt5 cf">

--- a/src/templates/docs/floats/index.html
+++ b/src/templates/docs/floats/index.html
@@ -63,7 +63,7 @@
         <p class="f3">Originally floats were used to wrap text around images as in the example below.</p>
         <div class="cf">
           <img src="/img/example-1.jpg" class="fl w4 mr3" alt="example 1">
-          <p class="measure mtn">
+          <p class="measure mt0">
             Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
             tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
             vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,

--- a/src/templates/docs/line-height/index.html
+++ b/src/templates/docs/line-height/index.html
@@ -63,15 +63,15 @@
           no sea takimata sanctus est Lorem ipsum dolor sit amet.
         </p>
         <h3 class="f5 book ptxl ttu">No Applied Title Leading (Default)</h3>
-        <p class="measure ttu mega fw6 mtn">
+        <p class="measure ttu f-5 fw6 mt0">
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr
         </p>
         <h3 class="f5 book ptxl ttu">Title Leading (1.3)</h3>
-        <p class="measure lh-title ttu mega fw6 mtn">
+        <p class="measure lh-title ttu f-5 fw6 mt0">
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr
         </p>
         <h3 class="f5 book ptxl ttu">Solid Leading (1)</h3>
-        <p class="measure lh-solid ttu mega fw6 mtn">
+        <p class="measure lh-solid ttu f-5 fw6 mt0">
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr
         </p>
         <div class="mt5 cf">

--- a/src/templates/docs/measure/avenir-next/index.html
+++ b/src/templates/docs/measure/avenir-next/index.html
@@ -15,7 +15,7 @@
     <header class="bg-black-025 black-70 pb4 sans-serif">
 
       <div class="bb b--black-10 ph3 ph4-ns pv4">
-        <h1 class="f4 f3-ns ttu mtn heavy tracked"><a class="black-40 link dim" href="/">Tachyons</a></h1>
+        <h1 class="f4 f3-ns ttu mt0 heavy tracked"><a class="black-40 link dim" href="/">Tachyons</a></h1>
         <h2 class="f4 mv0 fw6 dib pr1"><a class="black-40 link dim" href="/docs/">Docs</a></h2>
         <span class="fw2 black-40">/</span>
         <h3 class="f4 mv0 fw6 dib pr1"><a class="black-40 link dim" href="/docs/#typography">Typography</a></h3>
@@ -33,7 +33,7 @@
             <dd class="f2 f1-ns b db pl0 ml0"><%= moduleSize %></dd>
           </dl>
           <div class="cf">
-            <dl class="black-40 dib mrm mtn">
+            <dl class="black-40 dib mrm mt0">
               <dt class="db">Declarations </dt>
               <dd class="db pl0 ml0 f2 f1-ns b"><%= moduleObj.declarations.total %></span></dd>
             </dl>
@@ -67,7 +67,7 @@
     <main class="sans-serif">
       <div class="ph3 ph4-ns">
         <h1 class="f5 book sans-serif ptxl ttu black-100">Avenir Next set to <b>4rem/64px</b> at <b>30em</b></h1>
-        <p class="mega measure lh-title mtl">
+        <p class="f-5 measure lh-title mtl">
           <span class="">
             Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
             tempor invidunt ut labore et dolore magna aliquyam erat.
@@ -90,7 +90,7 @@
 knock dish off table head butt cant eat out of my own dish chew foot, and stick
 butt in face.
             </p>
-            <p class="f2 measure indent lh-title tj mtn">
+            <p class="f2 measure indent lh-title tj mt0">
             Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
             tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
             vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
@@ -131,7 +131,7 @@ butt in face.
           vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
           no sea takimata sanctus est Lorem ipsum dolor sit amet.
         </p>
-<p class="f4 measure lh-copy indent tj mtn">
+<p class="f4 measure lh-copy indent tj mt0">
 The Decameron (From the Greek: δέκα - ten & μέρα - day) (Italian: Decameron [deˈkaːmeron] or Decamerone [dekameˈroːne]), subtitled Prince Galehaut (Old Italian: Prencipe Galeotto [ˌprentʃipe ɡaleˈɔtto]), is a collection of novellas by the 14th-century Italian author Giovanni Boccaccio (1313–1375). The book is structured as a frame story containing 100 tales told by a group of seven young women and three young men sheltering in a secluded villa just outside Florence to escape the Black Death, which was afflicting the city. Boccaccio probably conceived the Decameron after the epidemic of 1348, and completed it by 1353. The various tales of love in The Deca
 
 </p>

--- a/src/templates/docs/measure/georgia/index.html
+++ b/src/templates/docs/measure/georgia/index.html
@@ -14,7 +14,7 @@
   <body class="garamond w-100">
     <header class="bg-dark-gray white pbl sans-serif">
       <div class="bb b--mid-gray phm phl-ns pvl">
-        <h1 class="f4 ttu mtn heavy tracked"><a class="white link dim" href="/">Tachyons</a></h1>
+        <h1 class="f4 ttu mt0 heavy tracked"><a class="white link dim" href="/">Tachyons</a></h1>
         <h2 class="f4 mvn semibold dib prxs"><a class="lightest-blue link dim" href="/docs/">Docs</a></h2>
         <span class="thin white-40">/</span>
         <h3 class="f4 mvn semibold dib prxs"><a class="lightest-blue link dim" href="/docs/#typography">Typography</a></h3>
@@ -32,7 +32,7 @@
             <dd class="f2 f1-ns b db pln mln"><%= moduleSize %></dd>
           </dl>
           <div class="cf">
-            <dl class="white-60 dib mrm mtn">
+            <dl class="white-60 dib mrm mt0">
               <dt class="db">Declarations </dt>
               <dd class="db pln mln f2 f1-ns b"><%= moduleObj.declarations.total %></span></dd>
             </dl>

--- a/src/templates/docs/measure/times/index.html
+++ b/src/templates/docs/measure/times/index.html
@@ -14,7 +14,7 @@
   <body class="serif w-100">
     <header class="bg-dark-gray white pbl sans-serif">
       <div class="bb b--mid-gray phm phl-ns pvl">
-        <h1 class="f4 ttu mtn heavy tracked"><a class="white link dim" href="/">Tachyons</a></h1>
+        <h1 class="f4 ttu mt0 heavy tracked"><a class="white link dim" href="/">Tachyons</a></h1>
         <h2 class="f4 mvn semibold dib prxs"><a class="lightest-blue link dim" href="/docs/">Docs</a></h2>
         <span class="thin white-40">/</span>
         <h3 class="f4 mvn semibold dib prxs"><a class="lightest-blue link dim" href="/docs/#typography">Typography</a></h3>
@@ -32,7 +32,7 @@
             <dd class="f2 f1-ns b db pln mln"><%= moduleSize %></dd>
           </dl>
           <div class="cf">
-            <dl class="white-60 dib mrm mtn">
+            <dl class="white-60 dib mrm mt0">
               <dt class="db">Declarations </dt>
               <dd class="db pln mln f2 f1-ns b"><%= moduleObj.declarations.total %></span></dd>
             </dl>
@@ -66,7 +66,7 @@
     <main>
       <div class="phm phl-ns">
         <h1 class="f5 book sans-serif ptxl ttu black-100">Times set to <b>4rem/64px</b> at <b>30em</b></h1>
-        <p class="mega measure lh-title mtl">
+        <p class="f-5 measure lh-title mtl">
           <span class="">
             Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
             tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At


### PR DESCRIPTION
Update usages of `.mega` and `.mtn` to use `.f-5` and `.mt0` respectively.

Line height doc page **before**

![screenshot 2016-06-02 16 17 04](https://cloud.githubusercontent.com/assets/58871/15752646/fd2b3500-28e6-11e6-893b-29234d585b0e.png)


Line height doc page **after**

![screenshot 2016-06-02 17 24 39](https://cloud.githubusercontent.com/assets/58871/15752648/00430d80-28e7-11e6-9a33-9f1047cf9646.png)

