### PR TITLE
Makes Principles font sizes consistent

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -86,14 +86,14 @@ npm install &amp;&amp; npm build
               <div class="cf">
                 <article class="pv2 w-100 ">
                   <h2 class="f4 f1-m f-headline-l fw6 mb0">Responsive</h2>
-                  <p class="f5 f4-ns measure lh-copy mt0">
+                  <p class="f5 f3-ns measure lh-copy mt0">
                     Everything should be 100% responsive. Your website should work regardless of a users
                     device or screensize.
                   </p>
                 </article>
                 <article class="pv2 fl w-100 pl0 ">
                   <h2 class="f4 f1-m f-headline-l fw6 mb0">Readable</h2>
-                  <p class="f5 f4-ns measure lh-copy mt0">
+                  <p class="f5 f3-ns measure lh-copy mt0">
                     No matter the lighting, or the device, font-sizes should be
                     large enough and contrast should be high enough for your
                     users to easily read your content.


### PR DESCRIPTION
Responsive & Readable sections currently have smaller copy than the rest of the principles when not-small.

(I'm unable to run the build script for the homepage as ```tachyons-base``` ins't in the ```package.json```. I  wasn't sure if there was a reason for this, so I opted to leave it as is.)