### PR TITLE
untruncates broken npmcdn link in index.html

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -71,7 +71,7 @@
             <p class="measure lh-copy">
               Copy the line of code below and paste it in the head of the html file(s) you want to include tachyons in.
             </p>
-<pre class="pre white-70" style="overflow: auto"><code class="code f6 dib pa2 bg-black-20" style="font-size: 14px;">&lt;link rel="stylesheet" href="https://npmcdn.com/tachyons@4.0.1</code></pre>
+<pre class="pre white-70" style="overflow: auto"><code class="code f6 dib pa2 bg-black-20" style="font-size: 14px;">&lt;link rel="stylesheet" href="https://npmcdn.com/tachyons@4.0.1/css/tachyons.min.css"&gt;</code></pre>
 <p class="mt4"><b>or</b> install via npm</p>
 <pre class="pre white-70" style="overflow: auto"><code class="code f6 dib pa2 bg-black-20" style="font-size: 14px;">npm install --save-dev tachyons@4.0.1</code></pre>
 <p class="mt4"><b>or</b> grab all the source files and build+develop locally</p>


### PR DESCRIPTION
looks like [this commit](https://github.com/tachyons-css/tachyons-css.github.io/commit/8276de2f575a1a4a36f15cc1592ca7b9457b5427#diff-eacf331f0ffc35d4b482f1d15a887d3bL115) removed some characters following the version number on line 115 of index.html