### PR TITLE
Fix wrong Gallery links

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,19 +332,19 @@ npm install &amp;&amp; npm start
           <h3 class="f6 fw6 mt5 pt2 mb4 tc ttu tracked">Gallery</h3>
           <div class="dt dt--fixed center mw8 pb6">
             <article class="dtc pa1 pa3-l">
-              <a class="link dim shadow black-70 db" href="goldenstaterecord.com">
+              <a class="link dim shadow black-70 db" href="https://www.goldenstaterecord.com">
                 <img class="db w-100" src="img/goldenstate.png" alt="Screenshot of goldenstaterecord.com"/>
                 <span class="pt2 dn db-ns">goldenstaterecord.com</span>
               </a>
             </article>
             <article class="dtc pa1 pa3-l">
-              <a class="link dim shadow black-70 db" href="rescale.com">
+              <a class="link dim shadow black-70 db" href="http://rescale.com">
                 <img class="db w-100" src="img/rescale.png" alt="Screenshot of rescale.com"/>
                 <span class="pt2 dn db-ns">rescale.com</span>
               </a>
             </article>
             <article class="dtc pa1 pa3-l">
-              <a class="link dim shadow black-70 db" href="bluebottlecoffee.com">
+              <a class="link dim shadow black-70 db" href="https://bluebottlecoffee.com/">
                 <img class="db w-100" src="img/bluebottle.png" alt="Screenshot of bluebottlecoffee.com"/>
                 <span class="pt2 dn db-ns">bluebottlecoffee.com</span>
               </a>


### PR DESCRIPTION
The links for the gallery projects were redirecting to `http://tachyons.io/goldenstaterecord.com`, etc. This commit fixes them.
Thanks for an awesome project!