### PR TITLE
Updated Style Guide anchor & spelling

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,9 +330,9 @@ npm install &amp;&amp; npm start
 </div>
     </section>
     <section>
-<div class="ph3 ph5-ns pt5">
+<div class="ph3 ph5-ns pt5" id="style">
 <div class="mw9 center overflow-auto">
-    <h3 class="f5 fw6 ttu tracked">Tachyons Styleguide</h3>
+    <h3 class="f5 fw6 ttu tracked">Tachyons Style Guide</h3>
 <p class="lh-copy measure">
 This is a quick introduction to some of the building blocks that Tachyons makes available. For a more in-depth look at design principles and how each module works, be sure to check out the <a class="link blue underline hover-navy" href="/docs" title="Tachyons docs">docs</a>
 </p>


### PR DESCRIPTION
Style Guide was missing it’s anchor to jump from the nag bar.

Was written as “Styleguide”.