### PR TITLE
Add a quick cson build for atom-tachyons

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "doc:lib": "watch 'npm run doc' lib",
     "doc:images": "watch 'node src/modules/images.js' src/templates/docs/images",
     "doc:bgsize": "watch 'node src/modules/background-size.js' src/templates/docs/background-size",
-    "build:all": "node build.js && bash script.sh"
+    "build:all": "node build.js && bash script.sh",
+    "cson": "node src/components-cson-build.js"
   },
   "repository": "tachyons-css/tachyons-css.github.io",
   "author": "mrmrs",

--- a/src/components-cson-build.js
+++ b/src/components-cson-build.js
@@ -1,0 +1,42 @@
+var fs = require('fs')
+var _ = require('lodash')
+var path = require('path')
+var glob = require('glob')
+var titleize = require('titleize')
+var fm = require('json-front-matter')
+var rmHtmlExt = require('remove-html-extension')
+
+glob('src/components/**/*.html', {}, function (err, components) {
+  if (err) {
+    console.error(err)
+    return
+  }
+
+  var cson = '".text.html":\n\n'
+  components.forEach(function (component) {
+    var prefix = rmHtmlExt(component.replace('src/components/', '')).split('/')[1]
+    var componentHtml = fs.readFileSync(component, 'utf8')
+
+    var fmParsed = fm.parse(componentHtml)
+    var frontMatter = fmParsed.attributes || {}
+
+    cson += `
+    '${frontMatter.title || getTitle(component)}':
+      'prefix': '${prefix}'
+      'body': """
+      ${fmParsed.body.trim()}
+      """
+`
+  })
+
+  console.log(cson)
+})
+
+function getTitle(component) {
+  var title = rmHtmlExt(component).replace('src/components/', '').replace(/(\/|_|-)/g, ' ')
+  return titleize(title)
+}
+
+function getName(component) {
+  return titleize(getTitle(component.split('/')[3]))
+}


### PR DESCRIPTION
As a potential way to help the atom-tachyons keep
their package up to date I've added a cson build
script that generates most of the output that the
atom extension ecosystem likes.

This can be run with

    npm run cson

It will output everything to stdout. We may want
to perhaps write to a file instead?

This comes with the caveat that it doesn't include
the string templating syntax found here
https://github.com/calweb/atom-tachyons/blob/1f956950e5d1982fe0c2a2d157fa694e60bee78d/snippets/components.cson#L6

***

Related calweb/atom-tachyons#1