### PR TITLE
docs: fix trailing whitespace in docs templates

### DIFF
--- a/src/templates/components-index.html
+++ b/src/templates/components-index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="Tachyons Components">
   <%= head %>
   <style type="text/css" media="screen">
-    .transparent { color: transparent; } 
+    .transparent { color: transparent; }
   </style>
 </head>
 <body class="w-100 sans-serif">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -28,7 +28,7 @@
               </a>
               <a title="Style Guide" href="#style"
                   class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
-                Style Guide 
+                Style Guide
               </a>
               <a title="Testimonials" href="#testimonials"
                   class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
@@ -64,8 +64,8 @@
                   </p>
                 </div>
                 <div class="fl-l w-50-l tl tc-ns pt3 pt4-m pt6-l">
-                  <a 
-                    class="f6 f5-ns fw6 dib ba b--black-20 bg-blue white ph3 ph4-ns pv2 pv3-ns br2 grow no-underline" 
+                  <a
+                    class="f6 f5-ns fw6 dib ba b--black-20 bg-blue white ph3 ph4-ns pv2 pv3-ns br2 grow no-underline"
                     href="https://raw.githubusercontent.com/tachyons-css/tachyons/master/css/tachyons.min.css">
                     Download <code class="f6 fw4 di">v<%= version %></code>
                   </a>
@@ -212,7 +212,7 @@ npm install &amp;&amp; npm start
                 <article class="pv2 fl w-100 w-50-l pr0 pr2-l">
                   <h2 class="f4 f2-ns fw6 mb2">Functional</h2>
                   <p class="f5 measure lh-copy mt0">
-                    Tachyons works well with 
+                    Tachyons works well with
                   </p>
                 </article>
                 <article class="pv2 fl w-100 w-50-l pl0 pl2-l">
@@ -322,9 +322,9 @@ npm install &amp;&amp; npm start
     <section class="tc pv5 bb bt b--black-10 bg-washed-blue">
 <div class="ph3 ph5-ns">
       <h3 class="f5 fw6 ttu tracked black-70 mb4">Start using Tachyons</h3>
-      <a class="no-underline grow pa3 br2 bg-blue white mr3 mb3 dib" href="/docs/">Read the Docs</a> 
-      <a class="no-underline grow pa3 br2 bg-blue white mr3 mb3 dib" href="/components/">View Component Library</a> 
-      <a class="no-underline grow pa3 br2 bg-blue white mr3 dib" href="http://unpkg.com/tachyons/css/tachyons.min.css">Download the Code</a> 
+      <a class="no-underline grow pa3 br2 bg-blue white mr3 mb3 dib" href="/docs/">Read the Docs</a>
+      <a class="no-underline grow pa3 br2 bg-blue white mr3 mb3 dib" href="/components/">View Component Library</a>
+      <a class="no-underline grow pa3 br2 bg-blue white mr3 dib" href="http://unpkg.com/tachyons/css/tachyons.min.css">Download the Code</a>
 </div>
     </section>
     <section>
@@ -361,12 +361,12 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
       <h3 class="f6 ttu fw6 mt0 mb3 bb pb2">Type Styles</h3>
       <div class="dt-ns dt--fixed-ns">
         <div class="dtc v-mid">
-      <p class="i">Italicize: to write or print (text) in italics.</p>  
-      <p class="b">Some text that needs to be super bold.</p>  
-      <p class="underline">This text wants to be underlined.</p>  
-      <p class="strike">This text should be crossed out.</p>  
-      <p class="ttc">This text should be capitalized.</p>  
-      <p class="ttu">This text should be uppercase.</p>  
+      <p class="i">Italicize: to write or print (text) in italics.</p>
+      <p class="b">Some text that needs to be super bold.</p>
+      <p class="underline">This text wants to be underlined.</p>
+      <p class="strike">This text should be crossed out.</p>
+      <p class="ttc">This text should be capitalized.</p>
+      <p class="ttu">This text should be uppercase.</p>
     </div>
     <div class="dtc-ns v-mid">
 <pre class="ba b--black-05  pa2 overflow-auto">
@@ -387,37 +387,37 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
       <div class="dt-ns dt--fixed-ns">
         <div class="dtc v-mid">
 <h4 class="f6 mb0 mt3">system serif</h4>
-      <p class="serif">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="serif">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">Athelas</h4>
-      <p class="athelas"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="athelas ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="athelas"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="athelas ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">georgia</h4>
-      <p class="georgia"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="georgia ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="georgia"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="georgia ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">garamond</h4>
-      <p class="garamond"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="garamond ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="garamond"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="garamond ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">baskerville</h4>
-      <p class="baskerville"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="baskerville ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="baskerville"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="baskerville ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">calisto</h4>
-      <p class="calisto"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="calisto ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="calisto"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="calisto ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">system sans-serif</h4>
-      <p class="sans-serif"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="sans-serif ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="sans-serif"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="sans-serif ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">Helvetica</h4>
-      <p class="helvetica"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="helvetica ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="helvetica"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="helvetica ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">Avenir Next</h4>
-      <p class="avenir"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="avenir ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="avenir"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="avenir ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">Code</h4>
-      <p class="code"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="code ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="code"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="code ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">Courier</h4>
-      <p class="code"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
-      <p class="code ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>  
+      <p class="code"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="code ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
     </div>
     <div class="dtc-ns v-mid">
 <pre class="ba b--black-05  pa2 overflow-auto">
@@ -437,7 +437,7 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
 .helvetica { font-family: 'helvetica neue', helvetica, sans-serif; }
 .avenir { font-family: 'avenir next', avenir, sans-serif; }
 .athelas { font-family: athelas, georgia, serif; }
-.georgia { font-family: georgia, serif; } 
+.georgia { font-family: georgia, serif; }
 .times { font-family: times, serif; }
 .bodoni { font-family: "Bodoni MT", serif; }
 .calisto { font-family: "Calisto MT", serif; }
@@ -460,7 +460,7 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
             aliquyam erat, sed diam voluptua. At vero eos et accusam et justo
             duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
             sanctus est Lorem ipsum dolor sit amet.
-          </p>  
+          </p>
           <h4 class="mt4 fw6 f6">Measure</h4>
           <p class="measure lh-copy">
             Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
@@ -468,7 +468,7 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
             aliquyam erat, sed diam voluptua. At vero eos et accusam et justo
             duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
             sanctus est Lorem ipsum dolor sit amet.
-          </p>  
+          </p>
           <h4 class="mt4 fw6 f6">Narrow Measure</h4>
           <p class="measure-narrow lh-copy">
              Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
@@ -476,7 +476,7 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
             aliquyam erat, sed diam voluptua. At vero eos et accusam et justo
             duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
             sanctus est Lorem ipsum dolor sit amet.
-          </p>  
+          </p>
       </div>
     <div class="dtc-ns v-mid">
 <pre class="ba b--black-05  pa2 overflow-auto">
@@ -496,7 +496,7 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
         <div class="mw9 center">
           <h3 class="f6 ttu fw6 mt0 bb pb2">Grids</h3>
           <p class="lh-copy measure">
-            Floats, widths, and padding can be combined to build a 
+            Floats, widths, and padding can be combined to build a
             wide variety of grids.
           </p>
         </div>
@@ -927,7 +927,7 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
           <div class="dtc v-mid"><div class="ba dib mb4 br-100 h3 w3 pa4 tc"></div></div>
           <div class="dtc v-mid"><div class="ba dib mb4 ph4 pv3  br-pill">pill</div></div>
 </div>
-          
+
           <div class="ba br--bottom dib ph4 pv3 mb4 br3">br--bottom</div>
           <div class="ba br--top dib ph4 pv3 mb4 br3">br--top</div><br>
           <div class="ba br--left dib ph4 pv3 mb4 br3">br--left</div>

--- a/src/templates/videos.html
+++ b/src/templates/videos.html
@@ -13,7 +13,7 @@
       <div class="ph3 ph5-ns">
         <div class="mw9 center">
           <header class="pv4 mb4 bb b--black-10">
-            <h2 class="f4 mt0 fw6">Videos</h2> 
+            <h2 class="f4 mt0 fw6">Videos</h2>
             <p>
               A collection of screencasts that demo various ways you can use Tachyons.
             </p>
@@ -23,7 +23,7 @@
               <iframe class="aspect-ratio--object" src="https://player.vimeo.com/video/183852299" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
             </div>
             <p class="lh-copy measure">
-              A quick demo on how to set line length so that 
+              A quick demo on how to set line length so that
               your text is easily readable.
             </p>
           </article>
@@ -47,7 +47,7 @@
               <iframe class="aspect-ratio--object" src="https://player.vimeo.com/video/183486778" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
             </div>
               <p class="lh-copy measure">Here is a simple html template that links to the latest version of Tachyons.</p>
-              <code class="pre f6"> 
+              <code class="pre f6">
 &lt;!DOCTYPE html&gt;
 &lt;html lang="en"&gt;
   &lt;head&gt;
@@ -77,9 +77,9 @@
               <p class="f6 lh-copy mb0 b">
                 To download and setup tachyons from github on the command line
               </p>
-              <code class="pre f6"> 
+              <code class="pre f6">
 git clone https://github.com/tachyons-css/tachyons.git  new-project
-or 
+or
 git clone git@github.com:tachyons-css/tachyons.git new-project
 cd new-project
 npm install &amp;&amp; npm start
@@ -88,7 +88,7 @@ npm install &amp;&amp; npm start
                 To install and setup browser-sync <span class="fw4"(you can use browser-sync
                   anywhere, not just with Tachyons).</span>
               </p>
-              <code class="pre f6"> 
+              <code class="pre f6">
 npm install -g browser-sync
 browser-sync start --server --files "*.html, */*.html"
               </code>


### PR DESCRIPTION
Removes extraneous whitespace in `src/templates/index.html`, `src/templates/videos.html`, & `src/templates/components-index.html`
