### PR TITLE
Vertically center links in header navs

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,23 +58,23 @@
           <header class="ph3 ph5-ns w-100 bg-transparent pv3 mb4 mb5-ns bb b--black-10 overflow-auto">
             <div class="nowrap mw9 center">
               <a title="Getting Started" href="#getting-started"
-                  class="pb2-ns f6 fw6 dim link black-70 mr2 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr2 mr3-m mr4-l dib">
                 Getting Started
               </a>
               <a title="Principles" href="#principles"
-                  class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
                 Principles
               </a>
               <a title="Features" href="#features"
-                  class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
                 Features
               </a>
               <a title="Style Guide" href="#style"
-                  class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
                 Style Guide 
               </a>
               <a title="Testimonials" href="#testimonials"
-                  class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
                 Testimonials
               </a>
             </div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -15,23 +15,23 @@
           <header class="ph3 ph5-ns w-100 bg-transparent pv3 mb4 mb5-ns bb b--black-10 overflow-auto">
             <div class="nowrap mw9 center">
               <a title="Getting Started" href="#getting-started"
-                  class="pb2-ns f6 fw6 dim link black-70 mr2 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr2 mr3-m mr4-l dib">
                 Getting Started
               </a>
               <a title="Principles" href="#principles"
-                  class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
                 Principles
               </a>
               <a title="Features" href="#features"
-                  class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
                 Features
               </a>
               <a title="Style Guide" href="#style"
-                  class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
                 Style Guide 
               </a>
               <a title="Testimonials" href="#testimonials"
-                  class="pb2-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
+                  class="pv1-ns f6 fw6 dim link black-70 mr1 mr3-m mr4-l dib">
                 Testimonials
               </a>
             </div>


### PR DESCRIPTION
This PR adjusts the spacing classes applied to the links in the secondary nav to center them vertically within its module.  

Before:
![image](https://cloud.githubusercontent.com/assets/1060893/18942335/4700c01c-85e6-11e6-89f1-a9755088bc5c.png)

After:
![image](https://cloud.githubusercontent.com/assets/1060893/18941804/137fb38c-85e2-11e6-8f3d-dd80a4a16b0f.png)

PS: tachyons is 😍 💥 !
