### PR TITLE
add missing overflow to the landing page code block

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -87,14 +87,19 @@
 cd tachyons
 npm install &amp;&amp; npm start
 </code></pre>
-<h3 class="f5 f3-ns mt4 fw6">Prototyping template</h3>
-<p class="lh-copy measure f6">
-  This template is always linked to the most up to date version of Tachyons.
-  Save this file to your computer to start prototyping right away without worrying
-  about setting up a dev environment. You can open the file in a web browser and view
-  your changes.
-</p>
-<code class="pre f6">
+<section class="cf">
+  <div class="fl w-100 w-third-l pr4-ns">
+    <h3 class="f5 f3-ns mt4 fw6">Prototyping template</h3>
+    <p class="lh-copy measure f6">
+      This template is always linked to the most up to date version of Tachyons.
+      Save this file to your computer to start prototyping right away without worrying
+      about setting up a dev environment. You can open the file in a web browser and view
+      your changes.
+    </p>
+  </div>
+  <div class="fl w-100 w-two-thirds-l">
+<pre class="ba b--black-10 pa3 overflow-auto">
+<code class="db f6 lh-copy">
 &lt;!DOCTYPE html&gt;
 &lt;html lang="en"&gt;
   &lt;title&gt; &lt;/title&gt;
@@ -105,9 +110,12 @@ npm install &amp;&amp; npm start
   &lt;/body&gt;
 &lt;/html&gt;
 </code>
+</pre>
+  </div>
+</section>
 
 <section class="bt b--black-10 pv5 mt5 cf">
-  <div class="fl-l w-100 w-50-l pr4-ns">
+  <div class="fl-l w-100 w-third-l pr4-ns">
     <h3 class="f5 f3-ns mt0">Start a New Project</h3>
     <p class="f6 f5-ns measure lh-copy mb4 mt0">
       Get setup and running with this ~7 minute screencast. Download the
@@ -115,7 +123,7 @@ npm install &amp;&amp; npm start
       recompile the css using the postcss build system.
     </p>
   </div>
-  <div class="fl-l w-100 w-50-l">
+  <div class="fl-l w-100 w-two-thirds-l">
     <div class="aspect-ratio aspect-ratio--8x5">
       <iframe class="aspect-ratio--object" src="https://player.vimeo.com/video/174698456" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
     </div>


### PR DESCRIPTION
**before** 

<img width="448" alt="screenshot 2016-10-24 21 13 33" src="https://cloud.githubusercontent.com/assets/8349161/19660100/d2445baa-9a2e-11e6-9266-4a4b57ded700.png">

**after**

<img width="1111" alt="screenshot 2016-10-24 21 13 46" src="https://cloud.githubusercontent.com/assets/8349161/19660116/e0cddb74-9a2e-11e6-90c6-a67460983771.png">
