### PR TITLE
Fix grid demo class typo (two-third-s -> two-thirds)

### DIFF
--- a/index.html
+++ b/index.html
@@ -603,7 +603,7 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
             <div class="outline bg-white tc pv4 truncate w-100 no-wrap"><code>fl w-third</code></div>
           </div>
           <div class="fl w-two-thirds pa2">
-            <div class="outline bg-white tc pv4 truncate w-100 no-wrap"><code>fl w-two-third-s</code></div>
+            <div class="outline bg-white tc pv4 truncate w-100 no-wrap"><code>fl w-two-thirds</code></div>
           </div>
           <div class="fl w-25 pa2">
             <div class="outline bg-white tc pv4"><code>fl w-25</code></div>


### PR DESCRIPTION
This is a tiny typo I just noticed. It probably just got caught in a find/replace, so thought I'd throw a quick PR your way!