### PR TITLE
Update url

### DIFF
--- a/docs/layout/clearfix/index.html
+++ b/docs/layout/clearfix/index.html
@@ -144,7 +144,7 @@
         </div>
         <div class="mt5">
           <h4 class="f6 fw6">Reference</h4>
-          <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/clears" class="link fw6 blue dim">MDN - Clears</a>
+          <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/clear" class="link fw6 blue dim">MDN - Clears</a>
         </div>
       </div>
       <section class="bg-white black-70 pt4 pb5 overflow-container">

--- a/src/templates/docs/clearfix/index.html
+++ b/src/templates/docs/clearfix/index.html
@@ -101,7 +101,7 @@
         </div>
         <div class="mt5">
           <h4 class="f6 fw6">Reference</h4>
-          <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/clears" class="link fw6 blue dim">MDN - Clears</a>
+          <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/clear" class="link fw6 blue dim">MDN - Clears</a>
         </div>
       </div>
       <section class="bg-white black-70 pt4 pb5 overflow-container">


### PR DESCRIPTION
There was a typo in the url which links to the clear CSS property docs on the Mozilla Developer Network which caused a 404. This pull request fixes the issue.