### PR TITLE
factorize component frontmatter defaults

### DIFF
--- a/build.js
+++ b/build.js
@@ -21,7 +21,18 @@ const componentsBuildScreenshots = require('./src/components-build-screenshots')
 
 // See src/components-build-defaults for list of options that can be overriden
 const options = {
-  // componentsGlobPattern: 'src/components/buttons/*.html',
+  components: {
+    globPattern: 'src/components/banners/*.html',
+    // frontMatter: {
+    //   bodyClass: 'bg-red',
+    //   screenshot: {
+    //     autocrop: false,
+    //   },
+    // },
+  },
+  // screenshot: {
+  //   aspectRatio: '16x9',
+  // },
 };
 
 // Note that componentsBuildIndex() generates the index *and* the JSON

--- a/src/components-build-defaults.js
+++ b/src/components-build-defaults.js
@@ -1,29 +1,46 @@
 module.exports = {
   // Components
-  componentsForNavPath: 'tmp/componentsForNav.json', // temporary file built by the index
-  componentsGlobPattern: 'src/components/**/*.html', // source components to process
-  componentsIndexPath: 'components/index.html',      // target location of components index
-  componentsBuildPages: true,                        // false to skip building pages
-  componentsBuildScreenshots: true,                  // false to skip building screenshots
-  // Screenshots
-  screenshotName: 'screenshot.jpg',                  // name JPEG screenshot in each component dir
-  screenshotAspectRatio: '4x3',                      // Tachyon aspect ratio of screenshot in index
-  screenshotViewportWidth: 1024,                     // viewport width used for capture
-  screenshotViewportHeight: 768,                     // viewport height used for capture
-  screenshotTargetMinWidth: 400,                     // min width of target, resized screenshot
-  screenshotTargetMinHeight: 160,                    // min height of target, resized screenshot
-  mozjpegQuality: 90,                                // mozjpeg optimizer quality (default 75)
-  screenshotSelector: '[data-name="component-container"]', // DOM element to capture
+  components: {
+    globPattern: 'src/components/**/*.html',    // source components to process
+    forNavPath: 'tmp/componentsForNav.json',    // temporary file built by the index
+    indexPath: 'components/index.html',         // target location of components index
+    buildPages: true,                           // false to skip building pages
+    buildScreenshots: true,                     // false to skip building screenshots
+    frontMatter: {                              // font matter defaults (i.e. optional)
+      name: undefined,                          // undefined to infer component name
+      title: undefined,                         // undefined to infer component title
+      bodyClass: 'bg-white',                    // class to apply on <body>
+      screenshot: {                             // per-component screenshot options
+        selector: '[data-name="component"]',    // DOM element to capture
+        autocrop: true,                         // autocrop the capture
+        'background-position': 'center center', // CSS background position
+        'background-size': 'cover',             // CSS background size ('cover', 'contain', 'auto')
+      },
+    },
+  },
+  // Screenshot options
+  // (components only for now, but could apply to other areas for consistency)
+  screenshot: {
+    basename: 'screenshot.jpg',                 // name of *JPEG* screenshot
+    aspectRatio: '4x3',                         // Tachyons aspect ratio of screenshots
+    viewportWidth: 1024,                        // viewport width used for capture
+    viewportHeight: 768,                        // viewport height used for capture
+    targetMinWidth: 400,                        // min width of target (final) screenshot
+    targetMinHeight: 160,                       // min height of target (final) screenshot
+    mozjpegQuality: 90,                         // mozjpeg optimizer quality (default 75)
+  },
   // Misc
   tachyonsCssPath: 'src/css/tachyons.css',
   serverPort: 3333,
   // Templates
-  analyticsTemplatePath: 'src/templates/ga.html',
-  componentsIndexTemplatePath: 'src/templates/components-index.html',
-  componentsTemplatePath: 'src/templates/components.html',
-  footerTemplatePath: 'src/templates/footer.html',
-  headerTemplatePath: 'src/templates/header.html',
-  headTemplatePath: 'src/templates/head.html',
-  highlightTemplatePath: 'src/templates/highlight.html',
-  lazysizesTemplate: 'src/templates/lazysizes.html',
+  templates: {
+    analyticsPath: 'src/templates/ga.html',
+    componentsIndexPath: 'src/templates/components-index.html',
+    componentPath: 'src/templates/component.html',
+    footerPath: 'src/templates/footer.html',
+    headerPath: 'src/templates/header.html',
+    headPath: 'src/templates/head.html',
+    highlightPath: 'src/templates/highlight.html',
+    lazysizesPath: 'src/templates/lazysizes.html',
+  },
 };

--- a/src/components-build-pages.js
+++ b/src/components-build-pages.js
@@ -23,25 +23,25 @@ const select = require('postcss-select');
 const defaults = require('./components-build-defaults');
 
 module.exports = _options => new Promise((resolve, reject) => {
-  const options = _.assign({}, defaults, _options);
+  const options = _.merge({}, defaults, _options);
   const startTime = process.hrtime();
   console.log(chalk.magenta('Working on components pages...'));
-  if (options.componentsForNavPath === undefined || !fs.existsSync(options.componentsForNavPath)) {
+  if (options.components.forNavPath === undefined || !fs.existsSync(options.components.forNavPath)) {
     reject('Can not find components nav JSON file');
     return;
   }
-  if (!options.componentsBuildPages) {
+  if (!options.components.buildPages) {
     console.log(chalk.dim('Skipped by request.'));
     resolve();
     return;
   }
-  const componentsForNav = JSON.parse(fs.readFileSync(options.componentsForNavPath, 'utf8'));
+  const componentsForNav = JSON.parse(fs.readFileSync(options.components.forNavPath, 'utf8'));
 
-  const componentTemplate = fs.readFileSync(options.componentsTemplatePath, 'utf8');
-  const analytics = fs.readFileSync(options.analyticsTemplatePath, 'utf8');
-  const footer = fs.readFileSync(options.footerTemplatePath, 'utf8');
-  const head = fs.readFileSync(options.headTemplatePath, 'utf8');
-  const highlight = fs.readFileSync(options.highlightTemplatePath, 'utf8');
+  const componentTemplate = fs.readFileSync(options.templates.componentPath, 'utf8');
+  const analytics = fs.readFileSync(options.templates.analyticsPath, 'utf8');
+  const footer = fs.readFileSync(options.templates.footerPath, 'utf8');
+  const head = fs.readFileSync(options.templates.headPath, 'utf8');
+  const highlight = fs.readFileSync(options.templates.highlightPath, 'utf8');
 
   const tachyonsCss = fs.readFileSync(options.tachyonsCssPath, 'utf8');
 
@@ -57,10 +57,9 @@ module.exports = _options => new Promise((resolve, reject) => {
         const componentHtml = fs.readFileSync(component.src, 'utf8');
         const fmParsed = fm.parse(componentHtml);
 
-        const frontMatter = _.assign({}, component.frontMatter);
+        const frontMatter = _.merge({}, options.components.frontMatter, component.frontMatter);
         frontMatter.title = component.title;
         frontMatter.name = component.name;
-        frontMatter.bodyClass = frontMatter.bodyClass || '';
         frontMatter.classes = getClasses(fmParsed.body).map(klass => `.${klass}`);
         frontMatter.componentHtml = componentHtml;
         frontMatter.content = fmParsed.body;

--- a/src/templates/component.html
+++ b/src/templates/component.html
@@ -7,7 +7,7 @@
 </head>
 <body class="w-100 sans-serif <%= bodyClass %>">
 <main>
-  <div data-name="component-container">
+  <div data-name="component">
   <%= content %>
   </div>
   <section data-name="component-info" class="pa3 pa5-ns bt b--black-10 black-70 bg-white">
@@ -64,8 +64,8 @@
   <% Object.keys(componentsForNav).map(function(category) { %>
     <div>
       <h2 class="f6 fw6 mb2 ttc black-70"><%= category %></h2>
-      <% componentsForNav[category].map(function(componentForNav) { %>
-        <a class="f6 f5-ns fw4 dib mr3 mb2 black-70 link hover-blue" href="<%= componentForNav.href %>"><%= componentForNav.name %></a>
+      <% componentsForNav[category].map(function(component) { %>
+        <a class="f6 f5-ns fw4 dib mr3 mb2 black-70 link hover-blue" href="<%= component.href %>"><%= component.name %></a>
       <% }) %>
     </div>
   <% }) %>

--- a/src/templates/components-index.html
+++ b/src/templates/components-index.html
@@ -30,17 +30,22 @@
       </div>
       <div class="ph3 ph5-ns mb5">
         <div class="mw9 center cf">
-          <% componentsForNav[category].map(function(componentForNav) { %>
+          <% componentsForNav[category].map(function(component) {
+               const frontMatter = _.merge({}, options.components.frontMatter, component.frontMatter);
+             %>
             <a class="db pointer link underline-hover black-70 fl w-50 w-third-m w-25-l pb2 pr2 border-box"
-               href="<%= componentForNav.href %>"
-               title="<%= componentForNav.name %>">
-              <div class="ba b--black-20 aspect-ratio aspect-ratio--<%= options.screenshotAspectRatio %>">
+               href="<%= component.href %>"
+               title="<%= component.name %>">
+              <div class="ba b--black-20 aspect-ratio aspect-ratio--<%= options.screenshot.aspectRatio %>">
                 <div class="aspect-ratio--object lazyload"
-                     data-bg="<%= componentForNav.screenshot.href %>"
-                     style="background-repeat: no-repeat; background-position: <%= componentForNav.frontMatter.screenshot && componentForNav.frontMatter.screenshot['background-position'] || 'center center' %>; background-size: <%= componentForNav.frontMatter.screenshot && componentForNav.frontMatter.screenshot['background-size'] || 'cover' %>;"></div>
+                     data-bg="<%= component.screenshot.href %>"
+                     style="background-repeat: no-repeat;
+                            background-position: <%= frontMatter.screenshot['background-position'] %>;
+                            background-size: <%= frontMatter.screenshot['background-size'] %>;">
+                </div>
               </div>
               <p class="f6 truncate">
-                <%= componentForNav.name %>
+                <%= component.name %>
               </p>
             </a>
           <% }) %>

--- a/src/templates/components-nav-template.html
+++ b/src/templates/components-nav-template.html
@@ -3,8 +3,8 @@
 <% Object.keys(componentsForNav).map(function(category) { %>
   <div>
     <h2 class="f6 fw6 mb2 ttc black-70"><%= category %></h2>
-    <% componentsForNav[category].map(function(componentForNav) { %>
-      <a class="f6 f5-ns fw4 dib mr3 mb2 black-70 link hover-blue dim" href="<%= componentForNav.href %>"><%= componentForNav.name %></a>
+    <% componentsForNav[category].map(function(component) { %>
+      <a class="f6 f5-ns fw4 dib mr3 mb2 black-70 link hover-blue dim" href="<%= component.href %>"><%= component.name %></a>
     <% }) %>
   </div>
 <% }) %>


### PR DESCRIPTION
Hey folks,
A quick improvement to the build options, trying to address two issues:
- the options that can be overridden in the component front matter are not documented,
- the default values for these options are buried inside the templates.

I moved all of them with the rest inside `src/build-components-defaults`:
- it is now easier to change these defaults (you can get rid of all your `"bodyClass" : "bg-white"` for example),
- they are documented,.
- you can override them from `build.js`, the same way you can override the other options,
- all the defaults have been organized into sub-objects, for clarity.
