### PR TITLE
Table Docs Clarification(?) maybe

### DIFF
--- a/docs/layout/display/index.html
+++ b/docs/layout/display/index.html
@@ -283,15 +283,15 @@ table-layout: fixed.
     d = display
 
    Modifiers:
-    n     = none
-    b     = block
-    ib    = inline-block
-    it    = inline-table
-    t     = table
-    tc    = table-cell
-    tr    = table-row
-    tcol  = table-column
-    tcolg = table-column-group
+    n              = none
+    b              = block
+    ib             = inline-block
+    it             = inline-table
+    t              = table
+    tc             = table-cell
+    t-row          = table-row
+    t-columm       = table-column
+    t-column-group = table-column-group
 
    Media Query Extensions:
      -ns = not-small


### PR DESCRIPTION
Not really sure if what I've changed here is right, or in the right format or maybe even I'm just reading the docs wrong. However, I tried adding a class of `.dtr` and noticed that there really wasn't a class for it and looked lower in the docs and saw that it was actually `.dt-row` so I thought this made things clear. 

Again, not sure if it's just me reading wrong, if so, please ignore this and I apologise for wasting anyones time. 