### PR TITLE
Fixed reference to wrong module in intro text

### DIFF
--- a/src/templates/docs/tables/index.html
+++ b/src/templates/docs/tables/index.html
@@ -21,7 +21,7 @@
       </header>
       <article class="pa3 ph5-ns">
         <p class="measure f4 f3-ns lh-copy">
-          Tachyons has some basic utilities for styling forms that are easy to customize and extend.
+          Tachyons has some basic utilities for styling tables that are easy to customize and extend.
         </p>
       </article>
       <div class="ph3 ph5-ns pt4 pb5">


### PR DESCRIPTION
Referenced forms instead of tables, probably copy-pasted.