### PR TITLE
Fix incorrect reference to _font-weight.css

### DIFF
--- a/docs/typography/font-weight/index.html
+++ b/docs/typography/font-weight/index.html
@@ -178,7 +178,7 @@
             <dd class="db pl0 ml0 f4 f2-ns b">1</dd>
           </dl>
         </div>
-        <kbd>src/_font-weights.css</kbd>
+        <kbd>src/_font-weight.css</kbd>
       </header>
 <pre class="ph3 ph5-ns">
 <code class="code" style="font-size: .75rem;">


### PR DESCRIPTION
This patch fixes a typo in the docs on font weight module: `_font-weights.css` -> `_font-weight.css`.

Real file is: https://github.com/tachyons-css/tachyons/blob/master/src/_font-weight.css