### PR TITLE
Add missing `ttu` class (tracking examples)

### DIFF
--- a/docs/typography/tracking/index.html
+++ b/docs/typography/tracking/index.html
@@ -117,7 +117,7 @@
         <code class="f6 fw4 mb3 mt4 db">
           &lt;h4 class="f1 ttu tracked-tight mt0"&gt;Title Example&lt;/h4&gt;
         </code>
-        <h4 class="f-headline tracked-tight b mt0">title example</h4>
+        <h4 class="f-headline ttu tracked-tight b mt0">title example</h4>
         <div class="mt5 cf">
           <div class="dib mr4">
             <h4 class="f6 fw6">Previous</h4>


### PR DESCRIPTION
Add a `ttu` class on the last tracking example, was _missing_.