### PR TITLE
Remove gray border around aspect-ratio layouts in Safari and Chrome

### DIFF
--- a/src/components/layout/full-bleed-16x9.html
+++ b/src/components/layout/full-bleed-16x9.html
@@ -9,121 +9,121 @@
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-           class="db bg-center cover aspect-ratio--object"></div>
+           class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
       <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-16x9.html
+++ b/src/components/layout/full-bleed-16x9.html
@@ -8,122 +8,122 @@
 <main class="cf w-100">
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
+           class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--16x9">
-      <img style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-4x6.html
+++ b/src/components/layout/full-bleed-4x6.html
@@ -9,121 +9,121 @@
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-           class="db bg-center cover aspect-ratio--object"></div>
+           class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
       <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-4x6.html
+++ b/src/components/layout/full-bleed-4x6.html
@@ -8,122 +8,122 @@
 <main class="cf w-100">
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
+           class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--4x6">
-      <img style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-5x7.html
+++ b/src/components/layout/full-bleed-5x7.html
@@ -8,122 +8,122 @@
 <main class="cf w-100">
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
-      <img style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-5x7.html
+++ b/src/components/layout/full-bleed-5x7.html
@@ -9,121 +9,121 @@
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x7">
       <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-5x8.html
+++ b/src/components/layout/full-bleed-5x8.html
@@ -8,122 +8,122 @@
 <main class="cf w-100">
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
-      <img style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-5x8.html
+++ b/src/components/layout/full-bleed-5x8.html
@@ -9,121 +9,121 @@
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--5x8">
       <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-6x4.html
+++ b/src/components/layout/full-bleed-6x4.html
@@ -8,122 +8,122 @@
 <main class="cf w-100">
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
-      <img style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
+        class="db bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-6x4.html
+++ b/src/components/layout/full-bleed-6x4.html
@@ -9,121 +9,121 @@
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--6x4">
       <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object"></div>
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-7x5.html
+++ b/src/components/layout/full-bleed-7x5.html
@@ -8,122 +8,122 @@
 <main class="cf w-100">
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--7x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-8x5.html
+++ b/src/components/layout/full-bleed-8x5.html
@@ -8,122 +8,122 @@
 <main class="cf w-100">
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--8x5">
-      <img style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>

--- a/src/components/layout/full-bleed-9x16.html
+++ b/src/components/layout/full-bleed-9x16.html
@@ -8,122 +8,122 @@
 <main class="cf w-100">
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0006.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0002.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0003.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0004.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0007.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0008.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0009.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0010.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0011.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0012.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0013.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0014.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0015.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0016.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0017.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0018.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0019.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0020.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0021.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
   <div class="fl w-50 w-third-m w-25-ns">
     <div class="aspect-ratio aspect-ratio--9x16">
-      <img style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
-        class="db bg-center cover aspect-ratio--object" />
+      <div style="background-image:url(http://mrmrs.github.io/images/0022.jpg);"
+        class="bg-center cover aspect-ratio--object"></div>
     </div>
   </div>
 </main>


### PR DESCRIPTION
This pull request fixes a browser bug in Safari and Chrome that places a gray border around images in `aspect-ratio` layouts. The simplest solution is just to change the `img` tag to a `div` tag. This solves the issue without additional CSS. In this case, the `img` tag is not necessary as there is no `src` attribute.

To view the problem, open any of the full bleed layout component pages in Chrome or Safari.

To understand the rationale behind this solution, see [this](https://stackoverflow.com/questions/6013071/removing-the-image-border-in-chrome-ie9/8984197#8984197) StackOverflow discussion.

Thanks to @MartinKavik for finding this solution.