### PR TITLE
Fixed typo for 2/3 value in calc.

### DIFF
--- a/docs/layout/widths/index.html
+++ b/docs/layout/widths/index.html
@@ -151,7 +151,7 @@ Modifiers
   -100 = literal value 100%
 
   -third  = calc(100% / 3)
-  -two-thirds  = calc(100% / 3)
+  -two-thirds  = calc(100% / 1.5)
   -auto  = string value auto
 
 


### PR DESCRIPTION
There was a simple typo in the docs for a 2/3 calculation.
Original: `-two-thirds  = calc(100% / 3)`
Fixed: `-two-thirds  = calc(100% / 1.5)`