### PR TITLE
Changed text to 'items-end'

### DIFF
--- a/src/templates/docs/flexbox/index.html
+++ b/src/templates/docs/flexbox/index.html
@@ -453,7 +453,7 @@
             <h4 class="f6 mb2 mt4">End</h4>
 
             <p class="measure f5 lh-copy">
-              Pack items from the end with <code>items-center</code>
+              Pack items from the end with <code>items-end</code>
             </p>
 
             <div class="flex flex-wrap">


### PR DESCRIPTION
The description for the `items-end` class was:

> Pack items from the end with <code>items-center</code>

Changed that to:

> Pack items from the end with <code>items-end</code>
