### PR TITLE
four-column-collapse-two component--broken image fix

### DIFF
--- a/components/layout/four-column-collapse-two/index.html
+++ b/components/layout/four-column-collapse-two/index.html
@@ -27,8 +27,8 @@
 <main>
   <div data-name="component">
   <section class="cf">
-  <div class="fl w-50 w-25-ns"><img class="db w-100" src="http://tachyons.io/img/1.jpg" alt="night sky over house"></div>
-  <div class="fl w-50 w-25-ns"><img class="db w-100" src="http://tachyons.io/img/2.jpg" alt="night sky over water"></div>
+  <div class="fl w-50 w-25-ns"><img class="db w-100" src="http://tachyons.io/img/3.jpg" alt="bay bridge at night"></div>
+  <div class="fl w-50 w-25-ns"><img class="db w-100" src="http://tachyons.io/img/4.jpg" alt="night sky over land"></div>
   <div class="fl w-50 w-25-ns"><img class="db w-100" src="http://tachyons.io/img/3.jpg" alt="bay bridge at night"></div>
   <div class="fl w-50 w-25-ns"><img class="db w-100" src="http://tachyons.io/img/4.jpg" alt="night sky over land"></div>
 
@@ -44,8 +44,8 @@
 <p class="f5 black-70"></p>
 <pre class="pa3 ba br2 b--black-10 h5 bg-white-20" id="html">
 &lt;section class=&quot;cf&quot;&gt;
-  &lt;div class=&quot;fl w-50 w-25-ns&quot;&gt;&lt;img class=&quot;db w-100&quot; src=&quot;http://tachyons.io/img/1.jpg&quot; alt=&quot;night sky over house&quot;&gt;&lt;/div&gt;
-  &lt;div class=&quot;fl w-50 w-25-ns&quot;&gt;&lt;img class=&quot;db w-100&quot; src=&quot;http://tachyons.io/img/2.jpg&quot; alt=&quot;night sky over water&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;fl w-50 w-25-ns&quot;&gt;&lt;img class=&quot;db w-100&quot; src=&quot;http://tachyons.io/img/3.jpg&quot; alt=&quot;bay bridge at night&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;fl w-50 w-25-ns&quot;&gt;&lt;img class=&quot;db w-100&quot; src=&quot;http://tachyons.io/img/4.jpg&quot; alt=&quot;night sky over land&quot;&gt;&lt;/div&gt;
   &lt;div class=&quot;fl w-50 w-25-ns&quot;&gt;&lt;img class=&quot;db w-100&quot; src=&quot;http://tachyons.io/img/3.jpg&quot; alt=&quot;bay bridge at night&quot;&gt;&lt;/div&gt;
   &lt;div class=&quot;fl w-50 w-25-ns&quot;&gt;&lt;img class=&quot;db w-100&quot; src=&quot;http://tachyons.io/img/4.jpg&quot; alt=&quot;night sky over land&quot;&gt;&lt;/div&gt;
 


### PR DESCRIPTION
The links for the first two images in the four-column-collapse-two component aren't working (http://tachyons.io/img/1.jpg, http://tachyons.io/img/2.jpg ). 

This PR uses the images in the two working links (3/4) and changes the alt text to match. 
