### PR TITLE
Fixed broken link

### DIFF
--- a/docs/debug-grid/index.html
+++ b/docs/debug-grid/index.html
@@ -181,7 +181,7 @@ if things are aligned. The background grid comes in both 8 and 16px columns.
         <div class="mt5 cf">
           <div class="dib mr4">
             <h4 class="f6 fw6">Previous</h4>
-            <a href="/docs/layout/debug/" class="link fw6 blue dim">Debug</a>
+            <a href="/docs/debug/" class="link fw6 blue dim">Debug</a>
           </div>
           <div class="dib">
             <h4 class="f6 fw6">Next</h4>

--- a/src/templates/docs/debug-grid/index.html
+++ b/src/templates/docs/debug-grid/index.html
@@ -90,7 +90,7 @@ if things are aligned. The background grid comes in both 8 and 16px columns.
         <div class="mt5 cf">
           <div class="dib mr4">
             <h4 class="f6 fw6">Previous</h4>
-            <a href="/docs/layout/debug/" class="link fw6 blue dim">Debug</a>
+            <a href="/docs/debug/" class="link fw6 blue dim">Debug</a>
           </div>
           <div class="dib">
             <h4 class="f6 fw6">Next</h4>


### PR DESCRIPTION
Currently, the Previous link throws a 404.

I have updated the link from (http://tachyons.io/docs/layout/debug/) to correct URL (http://tachyons.io/docs/debug/)