### PR TITLE
typo: references incorrect src file

### DIFF
--- a/docs/typography/font-family/index.html
+++ b/docs/typography/font-family/index.html
@@ -239,7 +239,7 @@
             <dd class="db pl0 ml0 f4 f2-ns b">1</dd>
           </dl>
         </div>
-        <kbd>src/_font-families.css</kbd>
+        <kbd>src/_font-family.css</kbd>
       </header>
 <pre class="ph3 ph5-ns">
 <code class="code" style="font-size: .75rem;">

--- a/src/templates/docs/font-family/index.html
+++ b/src/templates/docs/font-family/index.html
@@ -187,7 +187,7 @@
             <dd class="db pl0 ml0 f4 f2-ns b"><%= moduleObj.rules.size.average %></dd>
           </dl>
         </div>
-        <kbd>src/_font-families.css</kbd>
+        <kbd>src/_font-family.css</kbd>
       </header>
 <pre class="ph3 ph5-ns">
 <code class="code" style="font-size: .75rem;">


### PR DESCRIPTION
`src/_font-families` > `src/_font-family`