### PR TITLE
Example for tracking-light has different style and content than displayed

### DIFF
--- a/src/templates/docs/tracking/index.html
+++ b/src/templates/docs/tracking/index.html
@@ -65,7 +65,7 @@
         <code class="f6 fw4 mb3 mt4 db">
           &lt;h4 class="f1 ttu tracked-tight mt0"&gt;Title Example&lt;/h4&gt;
         </code>
-        <h4 class="f-headline tracked-tight b mt0">title example</h4>
+        <h4 class="f1 ttu tracked-tight mt0">Title Example</h4>
         <div class="mt5 cf">
           <div class="dib mr4">
             <h4 class="f6 fw6">Previous</h4>


### PR DESCRIPTION
In docs/typography/tracking/. 
Example for tracking-light has different style and content than displayed:` f-headline tracked-tight b mt0` instead of `f1 ttu tracked-tight mt0` also with lower case 'title example' content instead of 'Title Example' shown. Made them same. 

Cheers & thanks or tachyons, 

