### PR TITLE
Fix bad link for "The Form of the Book"

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -88,7 +88,7 @@
               </span>
             </div>
           </a>
-          <a class="fl w-100 w-50-m w-25-l border-box mb4 mb5-l link black hover-light-purple pr2-l border-box" href="https://www.amazon.com/gp/product/3721201450/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=3721201450&linkCode=as2&tag=mrmrs01-20&linkId=99a1d6ef57ecbd4a14e228a5120965b4">
+          <a class="fl w-100 w-50-m w-25-l border-box mb4 mb5-l link black hover-light-purple pr2-l border-box" href="https://www.amazon.com/gp/product/0881791164/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=3721201450&linkCode=as2&tag=mrmrs01-20&linkId=99a1d6ef57ecbd4a14e228a5120965b4">
             <div class="aspect-ratio-ns aspect-ratio--1x1-ns">
               <span class="aspect-ratio--object-ns flex items-center">
                 <span>


### PR DESCRIPTION
Previously it was pointing to "Grid Systems in Graphic Design".

(I preserved all other attributes in the link, including referral link)