### PR TITLE
Fix typeface sample for Courier in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,8 +472,8 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
       <p class="code"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
       <p class="code ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">Courier</h4>
-      <p class="code"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
-      <p class="code ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="courier"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="courier ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
     </div>
     <div class="dtc-ns v-mid">
 <pre class="ba b--black-05  pa2 overflow-auto">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -420,8 +420,8 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
       <p class="code"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
       <p class="code ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
 <h4 class="f6 mb0 mt3">Courier</h4>
-      <p class="code"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
-      <p class="code ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="courier"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+      <p class="courier ttu"> a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
     </div>
     <div class="dtc-ns v-mid">
 <pre class="ba b--black-05  pa2 overflow-auto">


### PR DESCRIPTION
The example for Courier in Typefaces was using `code` instead of `courier` for its class.

![image](https://user-images.githubusercontent.com/2073533/63215591-39c64780-c0ff-11e9-9075-705e70413c9f.png)

![image](https://user-images.githubusercontent.com/2073533/63215597-4c408100-c0ff-11e9-8baf-77de24fc6cc0.png)
