### PR TITLE
Add proper class on Courier font family example

### DIFF
--- a/docs/typography/font-family/index.html
+++ b/docs/typography/font-family/index.html
@@ -124,7 +124,7 @@
           no sea takimata sanctus est Lorem ipsum dolor sit amet.
         </p>
         <h3 class="f5 fw4 sans-serif pt4">Courier <span class="fw4 ttn">(Fallback: system monospace)</h3>
-        <p class="code lh-copy measure">
+        <p class="courier lh-copy measure">
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
           tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
           vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,


### PR DESCRIPTION
Just a small change that replaces `.code` with `.courier` on Courier font family example.

Fixes: https://github.com/tachyons-css/tachyons/issues/652