### PR TITLE
Fixed typo "Radii" -> "Radius"

### DIFF
--- a/index.html
+++ b/index.html
@@ -972,7 +972,7 @@ This is a quick introduction to some of the building blocks that Tachyons makes 
       </div>
     </article>
     <article class="mt5">
-      <h3 class="f6 ttu fw6 mt0 mb3 bb pb2">Border Radii</h3>
+      <h3 class="f6 ttu fw6 mt0 mb3 bb pb2">Border Radius</h3>
       <div class="dt-ns dt--fixed-ns">
         <div class="dtc-ns v-mid">
           <div class="ba dib ph4 pv3 mb4  br1">br1</div>


### PR DESCRIPTION
I was browsing the website when I found this tiny typo. Obviously not a major bug, but still it is nice to keep everything clean 😄 